### PR TITLE
set intake reader port for Jetson

### DIFF
--- a/zebROS_ws/src/behaviors/config/2023_intake_reader_config.yaml
+++ b/zebROS_ws/src/behaviors/config/2023_intake_reader_config.yaml
@@ -1,4 +1,6 @@
-port: /dev/ttyACM0
+port: /dev/PICOBEE
+# put the udev rule below in /etc/udev/rules.d/99-terabee-pico.rules
+# SUBSYSTEM=="tty",SUBSYSTEMS=="usb",DRIVERS=="usb",ATTRS{idVendor}=="2e8a",ATTRS{idProduct}=="0003",ATTRS{manufacturer}=="Raspberry Pi",ATTRS{product}=="PicoArduino",SYMLINK+="PICOBEE"
 baud: 921600
 samples: 2
 min_range: 0.05


### PR DESCRIPTION
the port is now `/dev/PICOBEE`. also, the udev rule to set this up is a comment in `zebROS_ws/src/behaviors/config/2023_intake_reader_config.yaml` in case it somehow gets deleted from the jetson or we use the other jetson.