### PR TITLE
Fix path follower after swerve orient changes

### DIFF
--- a/zebROS_ws/src/behaviors/config/auto_mode_config.yaml
+++ b/zebROS_ws/src/behaviors/config/auto_mode_config.yaml
@@ -27,7 +27,7 @@ auto_mode_5: ["balance_facing_away"]
 auto_mode_6: ["drive_out_community"]
 
 auto_mode_7: ["place_cone_high"]
-auto_mode_8: []
+auto_mode_8: ["drive_forward"]
 auto_mode_9: []
 
 # Examples

--- a/zebROS_ws/src/path_follower/config/path_follower_config.yaml
+++ b/zebROS_ws/src/path_follower/config/path_follower_config.yaml
@@ -1,17 +1,19 @@
 path_follower:
-    lookahead_distance: 0.4
     # Set odom topic from a launch file param to make it easier to use with sim odom
     # This fuses swerve_drive_controller/odom x&y strafe plus imu roll, pitch, yaw
     #odom_topic: "/swerve_imu_ukf/odometry/filtered"
     #odom_topic: "/frcrobot_jetson/swerve_drive_controller/odom"
     #pose_topic
-    use_odom_orientation: true # false == get yaw from IMU topic instead
+
     # Set this as a param so sim can use fake odom while the real robot
-    # uses ZED pose
+    # uses ZED pose. 
+    # TODO : have an external node which translates from odom -> pose
+    # and just have the path follower pull in that pose msg
     #use_pose_for_odom : true # true == use PoseStamped subscriber (e.g. zed camera pose) for odom rather than Odometry subscriber
     final_pos_tol: 0.01
     final_rot_tol: 0.005
     ros_rate: 100
     server_timeout: 15
-    start_point_radius: 0.05
     time_offset: 0.0
+
+    #debug: true


### PR DESCRIPTION
Need to transform from path centric to field
centric orientation when sending yaw setpoints
to teleop orient topic, since those messages
expect a field centric coord system