### PR TITLE
really fix path follower

### DIFF
--- a/zebROS_ws/src/path_follower/src/path_follower_server.cpp
+++ b/zebROS_ws/src/path_follower/src/path_follower_server.cpp
@@ -256,6 +256,7 @@ class PathAction
 				if (std::isfinite(command_msg.data))
 				{
 					orientation_command_pub_.publish(command_msg);
+					ROS_INFO_STREAM("Orientation: " << command_msg.data);
 				}
 
 				if (as_.isPreemptRequested() || !ros::ok())
@@ -293,7 +294,7 @@ class PathAction
 					y_axis.setState(odom_.pose.pose.position.y);
 
 					std_msgs::Float64 yaw_msg;
-					yaw_msg.data = path_follower_.getYaw(orientation_) - initial_field_relative_yaw;
+					yaw_msg.data = path_follower_.getYaw(odom_.pose.pose.orientation);
 					robot_relative_yaw_pub_.publish(yaw_msg);
 
 					r.sleep();


### PR DESCRIPTION
use odom orientation for robot relative yaw because that is what the path is computed relative to (don't use IMU orientation and start at zero, that only works if odom orientation is 0 when we start I think)