### PR TITLE
Align to grid now uses terabees

### DIFF
--- a/zebROS_ws/src/behavior_actions/action/AlignToGrid2023.action
+++ b/zebROS_ws/src/behavior_actions/action/AlignToGrid2023.action
@@ -4,6 +4,8 @@ uint8 grid_id
 uint8 BLUE=0
 uint8 RED=1
 uint8 alliance
+
+bool no_terabees # if true, align assuming the game piece is centered (ignore terabees)
 ---
 # result
 bool success


### PR DESCRIPTION
The path now centers the game piece relative to the node. It was very fun to test this in stage and be able to combine real sensor input and simulation.