### PR TITLE
M1

### DIFF
--- a/docker/docker-run-mac
+++ b/docker/docker-run-mac
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+dev_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+dev_dir="$( dirname "$dev_dir" )"
+
+set -e
+set -o pipefail
+
+docker run "$@" -it --net=host -v  /tmp/.X11-unix:/tmp/.X11-unix \
+ -v $HOME/2023RobotCode:/home/ubuntu/.2023RobotCode.readonly \
+ --ipc=host \
+ --shm-size=8G \
+ -e DISPLAY=host.docker.internal:0 -e NVIDIA_DRIVER_CAPABILITIES=all --privileged --user ubuntu frc900/zebros-2023-dev:latest /bin/bash

--- a/zebROS_ws/src/cmake_modules/CMakeOpt.cmake
+++ b/zebROS_ws/src/cmake_modules/CMakeOpt.cmake
@@ -13,11 +13,12 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 execute_process(COMMAND pgrep -f rosetta OUTPUT_VARIABLE OUT RESULT_VARIABLE INTEL)
-if(INTEL)
-  message("Intel")
-else()
-  message("M1, skipping -flto")
-endif()
+# Printouts removed to avoid spam
+# if(INTEL)
+#   message("Intel")
+# else()
+#   message("M1, skipping -flto")
+# endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>")

--- a/zebROS_ws/src/cmake_modules/CMakeOpt.cmake
+++ b/zebROS_ws/src/cmake_modules/CMakeOpt.cmake
@@ -12,6 +12,13 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 
+execute_process(COMMAND pgrep -f rosetta OUTPUT_VARIABLE OUT RESULT_VARIABLE INTEL)
+if(INTEL)
+  message("Intel")
+else()
+  message("M1, skipping -flto")
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>")
 add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-switch>")
@@ -31,7 +38,11 @@ else() # Native builds
   set (CMAKE_RANLIB "gcc-ranlib" )
   set (CMAKE_AR     "gcc-ar"     )
   
-  set (OPT_FLAGS "${OPT_FLAGS} -O3 -fno-finite-math-only -flto=auto -fno-fat-lto-objects -fuse-linker-plugin -ffunction-sections -fdata-sections -Wl,-gc-sections")
+  if(INTEL)
+    set (OPT_FLAGS "${OPT_FLAGS} -O3 -fno-finite-math-only -flto=auto -fno-fat-lto-objects -fuse-linker-plugin -ffunction-sections -fdata-sections -Wl,-gc-sections")
+  else()
+    set (OPT_FLAGS "${OPT_FLAGS} -O3 -fno-finite-math-only -fno-fat-lto-objects -fuse-linker-plugin -ffunction-sections -fdata-sections -Wl,-gc-sections")
+  endif()
   if (${CMAKE_LIBRARY_ARCHITECTURE} STREQUAL "arm-linux-gnueabihf") # Jetson TK1
 	set (OPT_FLAGS "${OPT_FLAGS} -mcpu=cortex-a15 -mfpu=neon-vfpv4 -fvect-cost-model")
     unset(CUDA_USE_STATIC_CUDA_RUNTIME CACHE)

--- a/zebROS_ws/src/cmake_modules/CMakeOpt.cmake
+++ b/zebROS_ws/src/cmake_modules/CMakeOpt.cmake
@@ -12,12 +12,12 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 
-execute_process(COMMAND pgrep -f rosetta OUTPUT_VARIABLE OUT RESULT_VARIABLE INTEL)
+execute_process(COMMAND pgrep -f rosetta OUTPUT_VARIABLE OUT RESULT_VARIABLE NOT_APPLE_SILICON)
 # Printouts removed to avoid spam
-# if(INTEL)
-#   message("Intel")
+# if(NOT_APPLE_SILICON)
+#   message("Not Apple Silicon")
 # else()
-#   message("M1, skipping -flto")
+#   message("Apple Silicon, skipping -flto")
 # endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -39,11 +39,12 @@ else() # Native builds
   set (CMAKE_RANLIB "gcc-ranlib" )
   set (CMAKE_AR     "gcc-ar"     )
   
-  if(INTEL)
-    set (OPT_FLAGS "${OPT_FLAGS} -O3 -fno-finite-math-only -flto=auto -fno-fat-lto-objects -fuse-linker-plugin -ffunction-sections -fdata-sections -Wl,-gc-sections")
-  else()
-    set (OPT_FLAGS "${OPT_FLAGS} -O3 -fno-finite-math-only -fno-fat-lto-objects -fuse-linker-plugin -ffunction-sections -fdata-sections -Wl,-gc-sections")
+  set (OPT_FLAGS "${OPT_FLAGS} -O3 -fno-finite-math-only -fno-fat-lto-objects -fuse-linker-plugin -ffunction-sections -fdata-sections -Wl,-gc-sections")
+  
+  if (NOT_APPLE_SILICON)
+    set (OPT_FLAGS "${OPT_FLAGS} -flto=auto")
   endif()
+
   if (${CMAKE_LIBRARY_ARCHITECTURE} STREQUAL "arm-linux-gnueabihf") # Jetson TK1
 	set (OPT_FLAGS "${OPT_FLAGS} -mcpu=cortex-a15 -mfpu=neon-vfpv4 -fvect-cost-model")
     unset(CUDA_USE_STATIC_CUDA_RUNTIME CACHE)


### PR DESCRIPTION
Disable `-flto` (link time optimization) on M1 Macs in order to get rid of "Bad file descriptor" errors.