### PR TITLE
Use yolo yaml for fake_goal_detect

### DIFF
--- a/zebROS_ws/src/controller_node/launch/2024_sim.launch
+++ b/zebROS_ws/src/controller_node/launch/2024_sim.launch
@@ -62,6 +62,9 @@
 	</group>
 
 	<node pkg="fake_sensors" type="fake_goal_detect_node" name="fake_goal_detect" >
+		<!-- rosparam won't load this yaml because there are numeric-only keys (TypeError: can only concatenate str (not "int") to str)
+			 so fake_goal_detect just loads the file and parses it using a regex :| -->
+		<!-- <rosparam command="load" file="$(find tf_object_detection)/src/FRC2024.yaml" ns="yolo_yaml" /> -->
 		<remap from="goal_detect_msg" to="/goal_detection/goal_detect_msg" />
 	</node>
 	<!-- 

--- a/zebROS_ws/src/fake_sensors/src/fake_goal_detect.cpp
+++ b/zebROS_ws/src/fake_sensors/src/fake_goal_detect.cpp
@@ -18,7 +18,7 @@
 
 std::map<int, std::string> parsePBTXT(std::string filename) {
 	std::map<int, std::string> pbtxtMap;
-	std::regex pbtxtRegex("id:[^\\d]*(\\d+)[\\w\\d\\s]+name:.*['\"](.+)['\"]"); // this feels like an evil thing to do, but whatever
+	std::regex pbtxtRegex("(\\d+): *(.+)"); // this feels like an evil thing to do, but whatever
 	// regexr.com/6dql5
 	std::ifstream t(filename);
 	std::stringstream fileContents;
@@ -29,6 +29,7 @@ std::map<int, std::string> parsePBTXT(std::string filename) {
 	std::string::const_iterator searchStart(str.cbegin());
 	while (std::regex_search(searchStart, str.cend(), res, pbtxtRegex))
 	{
+		std::cout << res[1] << " = " << res[2] << std::endl;
 		pbtxtMap[std::stoi(res[1])] = res[2];
 		searchStart = res.suffix().first;
 	}
@@ -144,7 +145,7 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "fake_goal_detect");
 
 	ros::NodeHandle nh;
-	FakeGoalDetection fakeGoalDetection(nh, parsePBTXT("/home/ubuntu/2023RobotCode/zebROS_ws/src/tf_object_detection/src/2023Game_label_map.pbtxt"));
+	FakeGoalDetection fakeGoalDetection(nh, parsePBTXT("/home/ubuntu/2023RobotCode/zebROS_ws/src/tf_object_detection/src/FRC2024.yaml"));
 
 	ros::spin();
 	return 0;


### PR DESCRIPTION
We're switching from using a `pbtxt` to using a `yaml` for object detection IDs, so this PR updates our `fake_goal_detect` node (responsible for publishing simulated object detections) to parse the yaml file instead. I tested this in Stage and it works.