### PR TITLE
Add initial attempt at 2024 button box controller

### DIFF
--- a/zebROS_ws/src/frc_msgs/msg/ButtonBoxState2024.msg
+++ b/zebROS_ws/src/frc_msgs/msg/ButtonBoxState2024.msg
@@ -37,6 +37,11 @@ bool climbButton
 bool climbPress
 bool climbRelease
 
+# subwoofer shoot
+bool subwooferShootButton
+bool subwooferShootPress
+bool subwooferShootRelease
+
 # momentary switch for speed
 # speed ===
 bool speedSwitchUpButton

--- a/zebROS_ws/src/frc_state_controllers/CMakeLists.txt
+++ b/zebROS_ws/src/frc_state_controllers/CMakeLists.txt
@@ -128,6 +128,7 @@ include_directories(
 add_library(frc_state_controller
 	src/button_box_state_controller.cpp
 	src/button_box_state_controller_2023.cpp
+	src/button_box_state_controller_2024.cpp
 	src/can_bus_status_state_controller.cpp
 	src/joint_mode_state_controller.cpp
 	src/joystick_state_controller.cpp

--- a/zebROS_ws/src/frc_state_controllers/frc_state_controller_plugin.xml
+++ b/zebROS_ws/src/frc_state_controllers/frc_state_controller_plugin.xml
@@ -10,6 +10,11 @@
 			Read button box info from hardware interface and publish it (2023 buttonbox)
 		</description>
 	</class>
+	<class name="button_box_state_controller_2024/ButtonBoxStateController_2024" type="button_box_state_controller::ButtonBoxStateController_2024" base_class_type="controller_interface::ControllerBase">
+		<description>
+			Read button box info from hardware interface and publish it (2024 buttonbox)
+		</description>
+	</class>
 	<class name="can_bus_status_state_controller/CANBusStatusStateController" type="can_bus_status_state_controller::CANBusStatusStateController" base_class_type="controller_interface::ControllerBase">
 		<description>
 			Read CTRE CAN bus status state info and publish it

--- a/zebROS_ws/src/frc_state_controllers/src/button_box_state_controller_2024.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/button_box_state_controller_2024.cpp
@@ -77,24 +77,36 @@ public:
              m.header.stamp = time;
 
              // If the buttons are pressed
-             // TODO - these button IDs are from 2023's button box, and need to be updated
-             // Need to add auto mode message, not yet sure how to decode that
-             m.lockingSwitchButton = bbs->getButton(0);
-             m.rightGreenButton = bbs->getButton(1);
-             m.leftGreenButton = bbs->getButton(2);
-             m.topGreenButton = bbs->getButton(3);
-             m.bottomGreenButton = bbs->getButton(4);
-             m.zeroButton = bbs->getButton(5);
-             m.backupButton1Button = bbs->getButton(6);
-             m.redButton = bbs->getButton(7);
-             m.backupButton2Button = bbs->getButton(8);
-             m.speedSwitchUpButton = bbs->getButton(9);
-             m.speedSwitchDownButton = bbs->getButton(10);
-             m.shooterArmUpButton = bbs->getButton(11);
-             m.shooterArmDownButton = bbs->getButton(13);
+             // TODO : test this using a real driver station
+             m.lockingSwitchButton = bbs->getButton(6);
+             m.rightGreenButton = bbs->getButton(16);
+             m.leftGreenButton = bbs->getButton(9);
+             m.topGreenButton = bbs->getButton(15);
+             m.bottomGreenButton = bbs->getButton(8);
+             m.zeroButton = bbs->getButton(1);
+             m.backupButton1Button = bbs->getButton(10);
+             m.redButton = bbs->getButton(11);
+             m.backupButton2Button = bbs->getButton(13);
+             m.speedSwitchUpButton = bbs->getButton(5);
+             m.speedSwitchDownButton = bbs->getButton(4);
+             m.shooterArmUpButton = bbs->getButton(3);
+             m.shooterArmDownButton = bbs->getButton(7);
              // Skip 13 (that's the Arduino LED)
-             m.trapButton = bbs->getButton(14);
-             m.climbButton = bbs->getButton(16);
+             m.trapButton = bbs->getButton(17);
+             m.climbButton = bbs->getButton(0);
+             m.subwooferShootButton = bbs->getButton(2);
+
+            constexpr uint8_t FIRST_AUTO_BUTTON = 19;
+            constexpr uint8_t NUM_AUTO_BUTTONS = 6;
+            m.auto_mode = 0;
+            for (uint8_t i = 0; i < NUM_AUTO_BUTTONS; i++)
+            {
+                if (bbs->getButton(FIRST_AUTO_BUTTON + i))
+                {
+                    m.auto_mode = i + 1;
+                    break;
+                }
+            }
 
              // Creating press booleans by comparing the last publish to the current one
              m.lockingSwitchPress   = !prev_button_box_msg_.lockingSwitchButton   && m.lockingSwitchButton;
@@ -112,6 +124,7 @@ public:
              m.shooterArmDownPress  = !prev_button_box_msg_.shooterArmDownButton  && m.shooterArmDownButton;
              m.trapPress            = !prev_button_box_msg_.trapButton            && m.trapButton;
              m.climbPress           = !prev_button_box_msg_.climbButton           && m.climbButton;
+             m.subwooferShootPress  = !prev_button_box_msg_.subwooferShootButton  && m.subwooferShootButton;
 
              // Creating release booleans by comparing the last publish to the current one
              m.lockingSwitchRelease   = prev_button_box_msg_.lockingSwitchButton   && !m.lockingSwitchButton;
@@ -129,6 +142,7 @@ public:
              m.shooterArmDownRelease  = prev_button_box_msg_.shooterArmDownButton  && !m.shooterArmDownButton;
              m.trapRelease            = prev_button_box_msg_.trapButton            && !m.trapButton;
              m.climbRelease           = prev_button_box_msg_.climbButton           && !m.climbButton;
+             m.subwooferShootRelease  = prev_button_box_msg_.subwooferShootButton  && !m.subwooferShootButton;
 
              realtime_pub_->unlockAndPublish();
              prev_button_box_msg_ = m;

--- a/zebROS_ws/src/frc_state_controllers/src/button_box_state_controller_2024.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/button_box_state_controller_2024.cpp
@@ -1,0 +1,151 @@
+#include <controller_interface/controller.h>
+#include <realtime_tools/realtime_publisher.h>
+#include <frc_msgs/ButtonBoxState2024.h>
+#include <frc_interfaces/joystick_interface.h>
+#include <pluginlib/class_list_macros.h>
+#include "periodic_interval_counter/periodic_interval_counter.h"
+
+namespace button_box_state_controller
+{
+class ButtonBoxStateController_2024 : public controller_interface::Controller<hardware_interface::JoystickStateInterface>
+{
+private:
+ hardware_interface::JoystickStateHandle button_box_state_;
+ std::unique_ptr<realtime_tools::RealtimePublisher<frc_msgs::ButtonBoxState2024>> realtime_pub_;
+ std::unique_ptr<PeriodicIntervalCounter> interval_counter_;
+ double publish_rate_{50};
+ frc_msgs::ButtonBoxState2024 prev_button_box_msg_;
+
+public:
+ ButtonBoxStateController_2024() = default;
+ bool init(hardware_interface::JoystickStateInterface *hw,
+          ros::NodeHandle                             &root_nh,
+          ros::NodeHandle                             &controller_nh) override
+ {
+     ROS_INFO_STREAM_NAMED("button_box_state_controller_2024", "init is running");
+     std::string name;
+     if (!controller_nh.getParam("name", name))
+     {
+         ROS_ERROR("Could not read button box name parameter in ButtonBox State Controller");
+         return false;
+     }
+
+     if (!controller_nh.getParam("publish_rate", publish_rate_))
+     {
+         ROS_WARN_STREAM("Could not read publish_rate in ButtonBox state controller, using default " << publish_rate_);
+     }
+     else if (publish_rate_ <= 0.0)
+     {
+         ROS_ERROR_STREAM("Invliad publish_rate in ButtonBox state controller (" << publish_rate_ << ")");
+         return false;
+     }
+     interval_counter_ = std::make_unique<PeriodicIntervalCounter>(publish_rate_);
+
+     std::vector<std::string> button_box_names = hw->getNames();
+     const auto it = std::find(button_box_names.begin(), button_box_names.end(), name);
+     if (it == button_box_names.cend())
+     {
+         ROS_ERROR_STREAM("Could not find requested name " << name << " in button box interface list");
+         return false;
+     }
+
+     button_box_state_ = hw->getHandle(*it);
+     const auto id = button_box_state_->getId();
+     std::stringstream pub_name;
+     // TODO : maybe use pub_names instead, or joy id unconditionally?
+     pub_name << "js" << id;
+
+     realtime_pub_ = std::make_unique<realtime_tools::RealtimePublisher<frc_msgs::ButtonBoxState2024>>(root_nh, pub_name.str(), 1);
+
+     return true;
+ }
+
+ void starting(const ros::Time &time) override
+ {
+     interval_counter_->reset();
+ }
+
+ void update(const ros::Time &time, const ros::Duration &period) override
+ {
+     if (interval_counter_->update(period))
+     {
+         if (realtime_pub_->trylock())
+         {
+             const auto &bbs = button_box_state_;
+             auto &m = realtime_pub_->msg_;
+
+             m.header.stamp = time;
+
+             // If the buttons are pressed
+             // TODO - these button IDs are from 2023's button box, and need to be updated
+             // Need to add auto mode message, not yet sure how to decode that
+             m.lockingSwitchButton = bbs->getButton(0);
+             m.rightGreenButton = bbs->getButton(1);
+             m.leftGreenButton = bbs->getButton(2);
+             m.topGreenButton = bbs->getButton(3);
+             m.bottomGreenButton = bbs->getButton(4);
+             m.zeroButton = bbs->getButton(5);
+             m.backupButton1Button = bbs->getButton(6);
+             m.redButton = bbs->getButton(7);
+             m.backupButton2Button = bbs->getButton(8);
+             m.speedSwitchUpButton = bbs->getButton(9);
+             m.speedSwitchDownButton = bbs->getButton(10);
+             m.shooterArmUpButton = bbs->getButton(11);
+             m.shooterArmDownButton = bbs->getButton(13);
+             // Skip 13 (that's the Arduino LED)
+             m.trapButton = bbs->getButton(14);
+             m.climbButton = bbs->getButton(16);
+
+             // Creating press booleans by comparing the last publish to the current one
+             m.lockingSwitchPress   = !prev_button_box_msg_.lockingSwitchButton   && m.lockingSwitchButton;
+             m.rightGreenPress      = !prev_button_box_msg_.rightGreenButton      && m.rightGreenButton;
+             m.leftGreenPress       = !prev_button_box_msg_.leftGreenButton       && m.leftGreenButton;
+             m.topGreenPress        = !prev_button_box_msg_.topGreenButton        && m.topGreenButton;
+             m.bottomGreenPress     = !prev_button_box_msg_.bottomGreenButton     && m.bottomGreenButton;
+             m.zeroPress            = !prev_button_box_msg_.zeroButton            && m.zeroButton;
+             m.backupButton1Press   = !prev_button_box_msg_.backupButton1Button   && m.backupButton1Button;
+             m.redPress             = !prev_button_box_msg_.redButton             && m.redButton;
+             m.backupButton2Press   = !prev_button_box_msg_.backupButton2Button   && m.backupButton2Button;
+             m.speedSwitchUpPress   = !prev_button_box_msg_.speedSwitchUpButton   && m.speedSwitchUpButton;
+             m.speedSwitchDownPress = !prev_button_box_msg_.speedSwitchDownButton && m.speedSwitchDownButton;
+             m.shooterArmUpPress    = !prev_button_box_msg_.shooterArmUpButton    && m.shooterArmUpButton;
+             m.shooterArmDownPress  = !prev_button_box_msg_.shooterArmDownButton  && m.shooterArmDownButton;
+             m.trapPress            = !prev_button_box_msg_.trapButton            && m.trapButton;
+             m.climbPress           = !prev_button_box_msg_.climbButton           && m.climbButton;
+
+             // Creating release booleans by comparing the last publish to the current one
+             m.lockingSwitchRelease   = prev_button_box_msg_.lockingSwitchButton   && !m.lockingSwitchButton;
+             m.rightGreenRelease      = prev_button_box_msg_.rightGreenButton      && !m.rightGreenButton;
+             m.leftGreenRelease       = prev_button_box_msg_.leftGreenButton       && !m.leftGreenButton;
+             m.topGreenRelease        = prev_button_box_msg_.topGreenButton        && !m.topGreenButton;
+             m.bottomGreenRelease     = prev_button_box_msg_.bottomGreenButton     && !m.bottomGreenButton;
+             m.zeroRelease            = prev_button_box_msg_.zeroButton            && !m.zeroButton;
+             m.backupButton1Release   = prev_button_box_msg_.backupButton1Button   && !m.backupButton1Button;
+             m.redRelease             = prev_button_box_msg_.redButton             && !m.redButton;
+             m.backupButton2Release   = prev_button_box_msg_.backupButton2Button   && !m.backupButton2Button;
+             m.speedSwitchUpRelease   = prev_button_box_msg_.speedSwitchUpButton   && !m.speedSwitchUpButton;
+             m.speedSwitchDownRelease = prev_button_box_msg_.speedSwitchDownButton && !m.speedSwitchDownButton;
+             m.shooterArmUpRelease    = prev_button_box_msg_.shooterArmUpButton    && !m.shooterArmUpButton;
+             m.shooterArmDownRelease  = prev_button_box_msg_.shooterArmDownButton  && !m.shooterArmDownButton;
+             m.trapRelease            = prev_button_box_msg_.trapButton            && !m.trapButton;
+             m.climbRelease           = prev_button_box_msg_.climbButton           && !m.climbButton;
+
+             realtime_pub_->unlockAndPublish();
+             prev_button_box_msg_ = m;
+         }
+         else
+         {
+             interval_counter_->force_publish();
+         }
+     }
+ }
+
+ void stopping(const ros::Time & ) override
+ {
+ }
+
+}; //class
+
+} // namespace
+
+PLUGINLIB_EXPORT_CLASS(button_box_state_controller::ButtonBoxStateController_2024, controller_interface::ControllerBase)

--- a/zebROS_ws/src/ros_control_boilerplate/config/2024_compbot_base_rio.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/2024_compbot_base_rio.yaml
@@ -117,7 +117,7 @@ joystick2_controller:
     publish_rate: 50
 
 button_box_controller:
-    type: button_box_state_controller_2023/ButtonBoxStateController_2023
+    type: button_box_state_controller_2024/ButtonBoxStateController_2024
     name: button_box
     publish_rate: 50
 

--- a/zebROS_ws/src/ros_control_boilerplate/config/2024_compbot_base_rio.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/2024_compbot_base_rio.yaml
@@ -26,7 +26,7 @@ generic_hw_control_loop:
 # of several types of HW interface : CAN_id, PWM_id, DIO_id, AIO_id, etc.
 hardware_interface:
    joints:
-       # 2022 joints
+       # 2024 joints
        #
        # Solenoids which are updated from controllers on the Jetson need
        # to be configured here so they can write to hardware attached

--- a/zebROS_ws/src/ros_control_boilerplate/config/robot_in_a_box_rio.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/robot_in_a_box_rio.yaml
@@ -39,7 +39,7 @@ hardware_interface:
        - {name: robot_code_ready_rio, local: true, type: ready}
 
 button_box_controller:
-    type: button_box_state_controller_2023/ButtonBoxStateController_2023
+    type: button_box_state_controller_2024/ButtonBoxStateController_2024
     name: button_box
     publish_rate: 50
        

--- a/zebROS_ws/src/ros_control_boilerplate/launch/robot_in_a_box_rio.launch
+++ b/zebROS_ws/src/ros_control_boilerplate/launch/robot_in_a_box_rio.launch
@@ -4,6 +4,7 @@
 	<arg name="debug" default="false" />
 	<arg unless="$(arg debug)" name="launch_prefix" value="" />
 	<arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+	<arg name="button_box" default="true" />
 
 	<arg name="hw_or_sim" default="hw" />
 
@@ -13,6 +14,9 @@
 		<node name="frcrobot_rio_$(arg hw_or_sim)_interface" pkg="ros_control_boilerplate" type="frcrobot_$(arg hw_or_sim)_main"
 			output="screen" launch-prefix="$(arg launch_prefix)">
 			<remap from="js0" to="joystick_states1"/>
+			<remap from="js1" to="button_box_states" if="$(arg button_box)"/>
+			<remap from="js1" to="joystick_states2" unless="$(arg button_box)"/>
+			<remap from="js2" to="joystick_states2" if="$(arg button_box)"/>
 		</node>
 
 		<!-- Load controller settings -->
@@ -26,6 +30,7 @@
 									robot_controller_state_controller
 									match_state_controller
 									joint_state_listener_controller
+									button_box_controller
 									robot_code_ready_controller" />
 	</group>
 </launch>

--- a/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2023.cpp
+++ b/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2023.cpp
@@ -478,7 +478,6 @@ void buttonBoxCallback(const frc_msgs::ButtonBoxState2023ConstPtr &button_box)
 		driver->moveDirection(0, -1, 0, config.button_move_speed);
 	}
 
-
 	if(button_box->leftGreenPress)
 	{
 		driver->moveDirection(0, -1, 0, config.button_move_speed);
@@ -491,7 +490,6 @@ void buttonBoxCallback(const frc_msgs::ButtonBoxState2023ConstPtr &button_box)
 	{
 		driver->moveDirection(0, 1, 0, config.button_move_speed);
 	}
-
 
 	if(button_box->topGreenPress)
 	{

--- a/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2024.cpp
+++ b/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2024.cpp
@@ -557,6 +557,16 @@ void buttonBoxCallback(const frc_msgs::ButtonBoxState2024ConstPtr &button_box)
 	{
 	}
 
+	if (button_box->subwooferShootButton)
+	{
+	}
+	if (button_box->subwooferShootPress)
+	{
+	}
+	if (button_box->subwooferShootRelease)
+	{
+	}
+
 	if (button_box->speedSwitchUpButton)
 	{
 	}
@@ -574,6 +584,11 @@ void buttonBoxCallback(const frc_msgs::ButtonBoxState2024ConstPtr &button_box)
 	{
 	}
 	if (button_box->speedSwitchDownRelease)
+	{
+	}
+
+	// Switch in middle position
+	if (!(button_box->speedSwitchDownButton || button_box->speedSwitchUpButton))
 	{
 	}
 
@@ -596,6 +611,12 @@ void buttonBoxCallback(const frc_msgs::ButtonBoxState2024ConstPtr &button_box)
 	if (button_box->shooterArmDownRelease)
 	{
 	}
+
+	// Switch in middle position
+	if (!(button_box->shooterArmDownButton || button_box->shooterArmUpButton))
+	{
+	}
+
 
 	if (button_box->rightGreenPress)
 	{

--- a/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2024.cpp
+++ b/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2024.cpp
@@ -2,7 +2,11 @@
 #define ROTATION_WITH_STICK
 
 #include "ros/ros.h"
+#include "std_srvs/Empty.h"
+
+#include "frc_msgs/ButtonBoxState2024.h"
 #include "frc_msgs/JoystickState.h"
+#include "imu_zero_msgs/ImuZeroAngle.h"
 //#define NEED_JOINT_STATES
 #ifdef NEED_JOINT_STATES
 #include "sensor_msgs/JointState.h"
@@ -465,11 +469,186 @@ void evaluateCommands(const frc_msgs::JoystickStateConstPtr& joystick_state, int
 	}
 }
 
-#if 0
 void buttonBoxCallback(const frc_msgs::ButtonBoxState2024ConstPtr &button_box)
 {
+
+	if (button_box->lockingSwitchButton)
+	{
+	}
+	if (button_box->lockingSwitchPress)
+	{
+	}
+	if (button_box->lockingSwitchRelease)
+	{
+	}
+
+	// TODO We'll probably want to check the actual value here
+	auto_calculator.set_auto_mode(button_box->auto_mode);
+
+ 
+	if(button_box->zeroButton) {
+	}
+	if(button_box->zeroPress) {
+		// for zeroing, assuming the robot starts facing away from the speaker (yes this is 2024 but we need to test it)
+		imu_zero_msgs::ImuZeroAngle imu_cmd;
+		if (alliance_color == frc_msgs::MatchSpecificData::ALLIANCE_COLOR_RED) {
+			ROS_INFO_STREAM("teleop_joystick_comp_2023 : red alliance");
+			imu_cmd.request.angle = 180.0;
+		} else {
+			ROS_INFO_STREAM("teleop_joystick_comp_2023 : blue or unknown alliance");
+			imu_cmd.request.angle = 0.0;
+		}
+		ROS_INFO_STREAM("teleop_joystick_comp_2023 : zeroing IMU to " << imu_cmd.request.angle);
+		IMUZeroSrv.call(imu_cmd);
+		ROS_INFO_STREAM("teleop_joystick_comp_2023 : zeroing swerve odom");
+		std_srvs::Empty odom_cmd;
+		SwerveOdomZeroSrv.call(odom_cmd);
+	}
+	if(button_box->zeroRelease) {
+	}
+
+	if (button_box->redButton)
+	{
+	}
+	if (button_box->redPress)
+	{
+	}
+	if (button_box->redRelease)
+	{
+	}
+
+	if (button_box->backupButton1Button)
+	{
+	}
+	if (button_box->backupButton1Press)
+	{
+	}
+	if (button_box->backupButton1Release)
+	{
+	}
+
+	if (button_box->backupButton2Button)
+	{
+	}
+	if (button_box->backupButton2Press)
+	{
+	}
+	if (button_box->backupButton2Release)
+	{
+	}
+
+	if (button_box->trapButton)
+	{
+	}
+	if (button_box->trapPress)
+	{
+	}
+	if (button_box->trapRelease)
+	{
+	}
+
+	if (button_box->climbButton)
+	{
+	}
+	if (button_box->climbPress)
+	{
+	}
+	if (button_box->climbRelease)
+	{
+	}
+
+	if (button_box->speedSwitchUpButton)
+	{
+	}
+	if (button_box->speedSwitchUpPress)
+	{
+	}
+	if (button_box->speedSwitchUpRelease)
+	{
+	}
+
+	if (button_box->speedSwitchDownButton)
+	{
+	}
+	if (button_box->speedSwitchDownPress)
+	{
+	}
+	if (button_box->speedSwitchDownRelease)
+	{
+	}
+
+	if (button_box->shooterArmUpButton)
+	{
+	}
+	if (button_box->shooterArmUpPress)
+	{
+	}
+	if (button_box->shooterArmUpRelease)
+	{
+	}
+
+	if (button_box->shooterArmDownButton)
+	{
+	}
+	if (button_box->shooterArmDownPress)
+	{
+	}
+	if (button_box->shooterArmDownRelease)
+	{
+	}
+
+	if (button_box->rightGreenPress)
+	{
+		driver->moveDirection(0, 1, 0, config.button_move_speed);
+	}
+	if (button_box->rightGreenButton)
+	{
+		driver->sendDirection(config.button_move_speed);
+	}
+	if (button_box->rightGreenRelease)
+	{
+		driver->moveDirection(0, -1, 0, config.button_move_speed);
+	}
+
+	if (button_box->leftGreenPress)
+	{
+		driver->moveDirection(0, -1, 0, config.button_move_speed);
+	}
+	if (button_box->leftGreenButton)
+	{
+		driver->sendDirection(config.button_move_speed);
+	}
+	if (button_box->leftGreenRelease)
+	{
+		driver->moveDirection(0, 1, 0, config.button_move_speed);
+	}
+
+	if (button_box->topGreenPress)
+	{
+		driver->moveDirection(1, 0, 0, config.button_move_speed);
+	}
+	if (button_box->topGreenButton)
+	{
+		driver->sendDirection(config.button_move_speed);
+	}
+	if (button_box->topGreenRelease)
+	{
+		driver->moveDirection(-1, 0, 0, config.button_move_speed);
+	}
+
+	if (button_box->bottomGreenPress)
+	{
+		driver->moveDirection(-1, 0, 0, config.button_move_speed);
+	}
+	if (button_box->bottomGreenButton)
+	{
+		driver->sendDirection(config.button_move_speed);
+	}
+	if (button_box->bottomGreenRelease)
+	{
+		driver->moveDirection(1, 0, 0, config.button_move_speed);
+	}
 }
-#endif
 
 #ifdef NEED_JOINT_STATES
 void jointStateCallback(const sensor_msgs::JointState &joint_state)
@@ -487,6 +666,6 @@ int main(int argc, char **argv)
 	TeleopInitializer initializer;
 	initializer.set_n_params(n_params);
 	initializer.init();
-	// ros::Subscriber button_box_sub = n.subscribe("/frcrobot_rio/button_box_states", 1, &buttonBoxCallback);
+	ros::Subscriber button_box_sub = n.subscribe("/frcrobot_rio/button_box_states", 1, &buttonBoxCallback);
 	return 0;
 }


### PR DESCRIPTION
Add new controller with updated msg fields. Button ids are almost certainly wrong but it is a start
Update teleop 2024 to handle this message, add empty code for buttons plus copy-paste imu zero and green button code from 2023 Update 2024 rio to launch 2024 button box controller

Note - the green buttons and zero should work on the 2023 physical button box.  Auto mode selection will be broken big time since there's nothing hooked up in the controller to read it.