### PR TITLE
Clean up talon->cancoder sim interactions

### DIFF
--- a/zebROS_ws/src/ctre_interfaces/CMakeLists.txt
+++ b/zebROS_ws/src/ctre_interfaces/CMakeLists.txt
@@ -121,8 +121,9 @@ include_directories(
 
 ## Declare a C++ library
 add_library(${PROJECT_NAME} STATIC
-  src/cancoder_state_interface.cpp
   src/cancoder_command_interface.cpp
+  src/cancoder_sim_command_interface.cpp
+  src/cancoder_state_interface.cpp
   src/canifier_command_interface.cpp
   src/canifier_state_interface.cpp
   src/latency_compensation_state_interface.cpp

--- a/zebROS_ws/src/ctre_interfaces/CMakeLists.txt
+++ b/zebROS_ws/src/ctre_interfaces/CMakeLists.txt
@@ -124,17 +124,18 @@ add_library(${PROJECT_NAME} STATIC
   src/cancoder_command_interface.cpp
   src/cancoder_sim_command_interface.cpp
   src/cancoder_state_interface.cpp
+  src/candle_state_interface.cpp
+  src/candle_command_interface.cpp
   src/canifier_command_interface.cpp
   src/canifier_state_interface.cpp
   src/latency_compensation_state_interface.cpp
+  src/orchestra_command_interface.cpp
+  src/orchestra_state_interface.cpp
   src/talon_command_interface.cpp
   src/talon_state_interface.cpp
   src/talonfxpro_command_interface.cpp
+  src/talonfxpro_sim_command_interface.cpp
   src/talonfxpro_state_interface.cpp
-  src/orchestra_command_interface.cpp
-  src/orchestra_state_interface.cpp
-  src/candle_state_interface.cpp
-  src/candle_command_interface.cpp
 )
 
 ## Add cmake target dependencies of the library

--- a/zebROS_ws/src/ctre_interfaces/include/ctre_interfaces/cancoder_sim_command_interface.h
+++ b/zebROS_ws/src/ctre_interfaces/include/ctre_interfaces/cancoder_sim_command_interface.h
@@ -1,0 +1,64 @@
+#ifndef CANCODER_SIM_COMMAND_INTERFACE_INC__
+#define CANCODER_SIM_COMMAND_INTERFACE_INC__
+
+#include "ctre_interfaces/cancoder_state_interface.h"
+#include "state_handle/command_handle.h"
+
+namespace hardware_interface::cancoder
+{
+class CANCoderSimCommand
+{
+	public:
+		CANCoderSimCommand(void);
+        void setSupplyVoltage(const double supply_voltage);
+        double getSupplyVoltage(void) const;
+        bool supplyVoltageChanged(double &supply_voltage);
+        void resetSupplyVoltage(void);
+
+        void setRawPosition(const double position);
+        double getRawPosition(void) const;
+        bool rawPositionChanged(double &position);
+        void resetRawPosition(void);
+
+        void setAddPosition(const double add_position);
+        double getAddPosition(void) const;
+        bool addPositionChanged(double &add_position);
+        void resetAddPosition(void);
+
+        void setVelocity(const double velocity);
+        double getVelocity(void) const;
+        bool velocityChanged(double &velocity);
+        void resetVelocity(void);
+
+        void setMagnetHealth(const MagnetHealth magnet_health);
+        MagnetHealth getMagnetHealth(void) const;
+        bool magnetHealthChanged(MagnetHealth &magnet_health);
+        void resetMagnetHealth(void);
+
+	private:
+        double supply_voltage_{0.0};
+        bool supply_voltage_changed_{false};
+        double raw_position_{0.0};
+        bool raw_position_changed_{false};
+        double add_position_{0.0};
+        bool add_position_changed_{false};
+        double velocity_{0.0};
+        bool velocity_changed_{false};
+        MagnetHealth magnet_health_{MagnetHealth::Invalid};
+        bool magnet_health_changed_{false};
+};
+
+// Handle - used by each controller to get, by name of the
+// corresponding joint, an interface with which to send commands
+// to a CANCoder
+using CANCoderSimCommandHandle = CommandHandle<CANCoderSimCommand, CANCoderHWState, CANCoderStateHandle>;
+
+
+// Use ClaimResources here since we only want 1 controller
+// to be able to access a given CANCoder at any particular time
+// TODO : is this true?  For sim stuff, do we need to worry about this?
+class CANCoderSimCommandInterface : public HardwareResourceManager<CANCoderSimCommandHandle, ClaimResources> {};
+
+} // namespace hardware_interface::cancoder
+
+#endif

--- a/zebROS_ws/src/ctre_interfaces/include/ctre_interfaces/cancoder_sim_command_interface.h
+++ b/zebROS_ws/src/ctre_interfaces/include/ctre_interfaces/cancoder_sim_command_interface.h
@@ -36,13 +36,15 @@ public:
         void resetMagnetHealth(void);
 
 private:
-        double supply_voltage_{0.0};
+        // Set these to NaN so that any new value will be different from
+        // the default initialized value and trigger a write to sim-hardware
+        double supply_voltage_{std::numeric_limits<double>::quiet_NaN()};
         bool supply_voltage_changed_{false};
-        double raw_position_{0.0};
+        double raw_position_{std::numeric_limits<double>::quiet_NaN()};
         bool raw_position_changed_{false};
-        double add_position_{0.0};
+        double add_position_{std::numeric_limits<double>::quiet_NaN()};
         bool add_position_changed_{false};
-        double velocity_{0.0};
+        double velocity_{std::numeric_limits<double>::quiet_NaN()};
         bool velocity_changed_{false};
         MagnetHealth magnet_health_{MagnetHealth::Invalid};
         bool magnet_health_changed_{false};

--- a/zebROS_ws/src/ctre_interfaces/include/ctre_interfaces/cancoder_sim_command_interface.h
+++ b/zebROS_ws/src/ctre_interfaces/include/ctre_interfaces/cancoder_sim_command_interface.h
@@ -8,8 +8,8 @@ namespace hardware_interface::cancoder
 {
 class CANCoderSimCommand
 {
-	public:
-		CANCoderSimCommand(void);
+public:
+        CANCoderSimCommand(void);
         void setSupplyVoltage(const double supply_voltage);
         double getSupplyVoltage(void) const;
         bool supplyVoltageChanged(double &supply_voltage);
@@ -35,7 +35,7 @@ class CANCoderSimCommand
         bool magnetHealthChanged(MagnetHealth &magnet_health);
         void resetMagnetHealth(void);
 
-	private:
+private:
         double supply_voltage_{0.0};
         bool supply_voltage_changed_{false};
         double raw_position_{0.0};
@@ -50,7 +50,7 @@ class CANCoderSimCommand
 
 // Handle - used by each controller to get, by name of the
 // corresponding joint, an interface with which to send commands
-// to a CANCoder
+// to a CANCoderimulator
 using CANCoderSimCommandHandle = CommandHandle<CANCoderSimCommand, CANCoderHWState, CANCoderStateHandle>;
 
 

--- a/zebROS_ws/src/ctre_interfaces/include/ctre_interfaces/talonfxpro_sim_command_interface.h
+++ b/zebROS_ws/src/ctre_interfaces/include/ctre_interfaces/talonfxpro_sim_command_interface.h
@@ -47,19 +47,21 @@ namespace hardware_interface::talonfxpro
         void resetRotorAcceleration(void);
 
     private:
-        double supply_voltage_{0.0};
+        // Set these to NaN so that any new value will be different from
+        // the default initialized value and trigger a write to sim-hardware
+        double supply_voltage_{std::numeric_limits<double>::quiet_NaN()};
         bool supply_voltage_changed_{false};
         bool forward_limit_{false};
         bool forward_limit_changed_{false};
         bool reverse_limit_{false};
         bool reverse_limit_changed_{false};
-        double rotor_position_{0.0};
+        double rotor_position_{std::numeric_limits<double>::quiet_NaN()};
         bool rotor_position_changed_{false};
-        double add_rotor_position_{0.0};
+        double add_rotor_position_{std::numeric_limits<double>::quiet_NaN()};
         bool add_rotor_position_changed_{false};
-        double rotor_velocity_{0.0};
+        double rotor_velocity_{std::numeric_limits<double>::quiet_NaN()};
         bool rotor_velocity_changed_{false};
-        double rotor_acceleration_{0.0};
+        double rotor_acceleration_{std::numeric_limits<double>::quiet_NaN()};
         bool rotor_acceleration_changed_{false};
     };
 

--- a/zebROS_ws/src/ctre_interfaces/include/ctre_interfaces/talonfxpro_sim_command_interface.h
+++ b/zebROS_ws/src/ctre_interfaces/include/ctre_interfaces/talonfxpro_sim_command_interface.h
@@ -1,0 +1,77 @@
+#ifndef TALONFXPRO_SIM_COMMAND_INTERFACE_INC__
+#define TALONFXPRO_SIM_COMMAND_INTERFACE_INC__
+
+#include "ctre_interfaces/talonfxpro_state_interface.h"
+#include "state_handle/command_handle.h"
+
+// TODO : there are various Get methods in the TalonFXProSimState class that are not used in the sim code
+namespace hardware_interface::talonfxpro
+{
+    class TalonFXProSimCommand
+    {
+    public:
+        TalonFXProSimCommand(void);
+        void setSupplyVoltage(const double supply_voltage);
+        double getSupplyVoltage(void) const;
+        bool supplyVoltageChanged(double &supply_voltage);
+        void resetSupplyVoltage(void);
+
+        void setForwardLimit(const bool forward_limit);
+        bool getForwardLimit(void) const;
+        bool forwardLimitChanged(bool &forward_limit);
+        void resetForwardLimit(void);
+
+        void setReverseLimit(const bool reverse_limit);
+        bool getReverseLimit(void) const;
+        bool reverseLimitChanged(bool &reverse_limit);
+        void resetReverseLimit(void);
+
+        void setRawRotorPosition(const double rotor_position);
+        double getRawRotorPosition(void) const;
+        bool rawPositionChanged(double &rotor_position);
+        void resetRawRotorPosition(void);
+
+        void setAddRotorPosition(const double add_rotor_position);
+        double getAddRotorPosition(void) const;
+        bool addPositionChanged(double &add_rotor_position);
+        void resetAddRotorPosition(void);
+
+        void setRotorVelocity(const double rotor_velocity);
+        double getRotorVelocity(void) const;
+        bool rotorVelocityChanged(double &rotor_velocity);
+        void resetRotorVelocity(void);
+
+        void setRotorAcceleration(const double acceleration);
+        double getRotorAcceleration(void) const;
+        bool accelerationChanged(double &acceleration);
+        void resetRotorAcceleration(void);
+
+    private:
+        double supply_voltage_{0.0};
+        bool supply_voltage_changed_{false};
+        bool forward_limit_{false};
+        bool forward_limit_changed_{false};
+        bool reverse_limit_{false};
+        bool reverse_limit_changed_{false};
+        double rotor_position_{0.0};
+        bool rotor_position_changed_{false};
+        double add_rotor_position_{0.0};
+        bool add_rotor_position_changed_{false};
+        double rotor_velocity_{0.0};
+        bool rotor_velocity_changed_{false};
+        double rotor_acceleration_{0.0};
+        bool rotor_acceleration_changed_{false};
+    };
+
+    // Handle - used by each controller to get, by name of the
+    // corresponding joint, an interface with which to send commands
+    // to a TalonFXPro simulator
+    using TalonFXProSimCommandHandle = CommandHandle<TalonFXProSimCommand, TalonFXProHWState, TalonFXProStateHandle>;
+
+    // Use ClaimResources here since we only want 1 controller
+    // to be able to access a given TalonFXPro at any particular time
+    // TODO : is this true?  For sim stuff, do we need to worry about this?
+    class TalonFXProSimCommandInterface : public HardwareResourceManager<TalonFXProSimCommandHandle, ClaimResources> {};
+}  // namespace hardware_interface::talonfxpro
+
+#endif // TALONFXPRO_SIM_COMMAND_INTERFACE_INC__

--- a/zebROS_ws/src/ctre_interfaces/src/cancoder_command_interface.cpp
+++ b/zebROS_ws/src/ctre_interfaces/src/cancoder_command_interface.cpp
@@ -1,13 +1,9 @@
 #include "ctre_interfaces/cancoder_command_interface.h"
 
-namespace hardware_interface
-{
-namespace cancoder
+namespace hardware_interface::cancoder
 {
 
-CANCoderHWCommand::CANCoderHWCommand(void)
-{
-}
+CANCoderHWCommand::CANCoderHWCommand(void) = default;
 
 double CANCoderHWCommand::getSetPosition(void) const
 {
@@ -122,6 +118,6 @@ bool CANCoderHWCommand::getEnableReadThread(void) const
 	return enable_read_thread_;
 }
 
-} // namespace hardware_interface
+// namespace hardware_interface
 } // namespace cancoder
 

--- a/zebROS_ws/src/ctre_interfaces/src/cancoder_sim_command_interface.cpp
+++ b/zebROS_ws/src/ctre_interfaces/src/cancoder_sim_command_interface.cpp
@@ -20,7 +20,7 @@ namespace hardware_interface::cancoder
     bool CANCoderSimCommand::supplyVoltageChanged(double &supply_voltage)
     {
         supply_voltage = supply_voltage_;
-        bool rc = supply_voltage_changed_;
+        const bool rc = supply_voltage_changed_;
         supply_voltage_changed_ = false;
         return rc;
     }
@@ -44,7 +44,7 @@ namespace hardware_interface::cancoder
     bool CANCoderSimCommand::rawPositionChanged(double &raw_position)
     {
         raw_position = raw_position_;
-        bool rc = raw_position_changed_;
+        const bool rc = raw_position_changed_;
         raw_position_changed_ = false;
         return rc;
     }
@@ -68,7 +68,7 @@ namespace hardware_interface::cancoder
     bool CANCoderSimCommand::addPositionChanged(double &add_position)
     {
         add_position = add_position_;
-        bool rc = add_position_changed_;
+        const bool rc = add_position_changed_;
         add_position_changed_ = false;
         return rc;
     }
@@ -92,7 +92,7 @@ namespace hardware_interface::cancoder
     bool CANCoderSimCommand::velocityChanged(double &velocity)
     {
         velocity = velocity_;
-        bool rc = velocity_changed_;
+        const bool rc = velocity_changed_;
         velocity_changed_ = false;
         return rc;
     }
@@ -116,7 +116,7 @@ namespace hardware_interface::cancoder
     bool CANCoderSimCommand::magnetHealthChanged(MagnetHealth &magnet_health)
     {
         magnet_health = magnet_health_;
-        bool rc = magnet_health_changed_;
+        const bool rc = magnet_health_changed_;
         magnet_health_changed_ = false;
         return rc;
     }

--- a/zebROS_ws/src/ctre_interfaces/src/cancoder_sim_command_interface.cpp
+++ b/zebROS_ws/src/ctre_interfaces/src/cancoder_sim_command_interface.cpp
@@ -1,0 +1,128 @@
+#include "ctre_interfaces/cancoder_sim_command_interface.h"
+
+namespace hardware_interface::cancoder
+{
+    CANCoderSimCommand::CANCoderSimCommand(void) = default;
+
+
+    double CANCoderSimCommand::getSupplyVoltage(void) const
+    {
+        return supply_voltage_;
+    }
+    void CANCoderSimCommand::setSupplyVoltage(const double supply_voltage)
+    {
+        if (supply_voltage != supply_voltage_)
+        {
+            supply_voltage_ = supply_voltage;
+            supply_voltage_changed_ = true;
+        }
+    }
+    bool CANCoderSimCommand::supplyVoltageChanged(double &supply_voltage)
+    {
+        supply_voltage = supply_voltage_;
+        bool rc = supply_voltage_changed_;
+        supply_voltage_changed_ = false;
+        return rc;
+    }
+    void CANCoderSimCommand::resetSupplyVoltage(void)
+    {
+        supply_voltage_changed_ = true;
+    }
+
+    double CANCoderSimCommand::getRawPosition(void) const
+    {
+        return raw_position_;
+    }
+    void CANCoderSimCommand::setRawPosition(const double raw_position)
+    {
+        if (raw_position != raw_position_)
+        {
+            raw_position_ = raw_position;
+            raw_position_changed_ = true;
+        }
+    }
+    bool CANCoderSimCommand::rawPositionChanged(double &raw_position)
+    {
+        raw_position = raw_position_;
+        bool rc = raw_position_changed_;
+        raw_position_changed_ = false;
+        return rc;
+    }
+    void CANCoderSimCommand::resetRawPosition(void)
+    {
+        raw_position_changed_ = true;
+    }
+
+    double CANCoderSimCommand::getAddPosition(void) const
+    {
+        return add_position_;
+    }
+    void CANCoderSimCommand::setAddPosition(const double add_position)
+    {
+        if (add_position != add_position_)
+        {
+            add_position_ = add_position;
+            add_position_changed_ = true;
+        }
+    }
+    bool CANCoderSimCommand::addPositionChanged(double &add_position)
+    {
+        add_position = add_position_;
+        bool rc = add_position_changed_;
+        add_position_changed_ = false;
+        return rc;
+    }
+    void CANCoderSimCommand::resetAddPosition(void)
+    {
+        add_position_changed_ = true;
+    }
+
+    double CANCoderSimCommand::getVelocity(void) const
+    {
+        return velocity_;
+    }
+    void CANCoderSimCommand::setVelocity(const double velocity)
+    {
+        if (velocity != velocity_)
+        {
+            velocity_ = velocity;
+            velocity_changed_ = true;
+        }
+    }
+    bool CANCoderSimCommand::velocityChanged(double &velocity)
+    {
+        velocity = velocity_;
+        bool rc = velocity_changed_;
+        velocity_changed_ = false;
+        return rc;
+    }
+    void CANCoderSimCommand::resetVelocity(void)
+    {
+        velocity_changed_ = true;
+    }
+
+    MagnetHealth CANCoderSimCommand::getMagnetHealth(void) const
+    {
+        return magnet_health_;
+    }
+    void CANCoderSimCommand::setMagnetHealth(const MagnetHealth magnet_health)
+    {
+        if (magnet_health != magnet_health_)
+        {
+            magnet_health_ = magnet_health;
+            magnet_health_changed_ = true;
+        }
+    }
+    bool CANCoderSimCommand::magnetHealthChanged(MagnetHealth &magnet_health)
+    {
+        magnet_health = magnet_health_;
+        bool rc = magnet_health_changed_;
+        magnet_health_changed_ = false;
+        return rc;
+    }
+    void CANCoderSimCommand::resetMagnetHealth(void)
+    {
+        magnet_health_changed_ = true;
+    }
+
+} // namespace hardware_interface::cancoder

--- a/zebROS_ws/src/ctre_interfaces/src/talonfxpro_sim_command_interface.cpp
+++ b/zebROS_ws/src/ctre_interfaces/src/talonfxpro_sim_command_interface.cpp
@@ -1,0 +1,175 @@
+#include "ctre_interfaces/talonfxpro_sim_command_interface.h"
+
+namespace hardware_interface::talonfxpro
+{
+TalonFXProSimCommand::TalonFXProSimCommand(void) = default;
+
+void TalonFXProSimCommand::setSupplyVoltage(const double supply_voltage)
+{
+    if (supply_voltage != supply_voltage_)
+    {
+        supply_voltage_ = supply_voltage;
+        supply_voltage_changed_ = true;
+    }
+}
+double TalonFXProSimCommand::getSupplyVoltage(void) const
+{
+    return supply_voltage_;
+}
+bool TalonFXProSimCommand::supplyVoltageChanged(double &supply_voltage)
+{
+    supply_voltage = supply_voltage_;
+    const bool rc = supply_voltage_changed_;
+    supply_voltage_changed_ = false;
+    return rc;
+}
+void TalonFXProSimCommand::resetSupplyVoltage(void)
+{
+    supply_voltage_changed_ = true;
+}
+
+bool TalonFXProSimCommand::forwardLimitChanged(bool &forward_limit)
+{
+    forward_limit = forward_limit_;
+    const bool rc = forward_limit_changed_;
+    forward_limit_changed_ = false;
+    return rc;
+}
+bool TalonFXProSimCommand::getForwardLimit(void) const
+{
+    return forward_limit_;
+}
+void TalonFXProSimCommand::setForwardLimit(const bool forward_limit)
+{
+    if (forward_limit != forward_limit_)
+    {
+        forward_limit_ = forward_limit;
+        forward_limit_changed_ = true;
+    }
+}
+void TalonFXProSimCommand::resetForwardLimit(void)
+{
+    forward_limit_changed_ = true;
+}
+
+bool TalonFXProSimCommand::reverseLimitChanged(bool &reverse_limit)
+{
+    reverse_limit = reverse_limit_;
+    const bool rc = reverse_limit_changed_;
+    reverse_limit_changed_ = false;
+    return rc;
+}
+bool TalonFXProSimCommand::getReverseLimit(void) const
+{
+    return reverse_limit_;
+}
+void TalonFXProSimCommand::setReverseLimit(const bool reverse_limit)
+{
+    if (reverse_limit != reverse_limit_)
+    {
+        reverse_limit_ = reverse_limit;
+        reverse_limit_changed_ = true;
+    }
+}
+void TalonFXProSimCommand::resetReverseLimit(void)
+{
+    reverse_limit_changed_ = true;
+}
+
+void TalonFXProSimCommand::setRawRotorPosition(const double rotor_position)
+{
+    if (rotor_position != rotor_position_)
+    {
+        rotor_position_ = rotor_position;
+        rotor_position_changed_ = true;
+    }
+}
+double TalonFXProSimCommand::getRawRotorPosition(void) const
+{
+    return rotor_position_;
+}
+bool TalonFXProSimCommand::rawPositionChanged(double &rotor_position)
+{
+    rotor_position = rotor_position_;
+    const bool rc = rotor_position_changed_;
+    rotor_position_changed_ = false;
+    return rc;
+}
+void TalonFXProSimCommand::resetRawRotorPosition(void)
+{
+    rotor_position_changed_ = true;
+}
+
+void TalonFXProSimCommand::setAddRotorPosition(const double add_rotor_position)
+{
+    if (add_rotor_position != add_rotor_position_)
+    {
+        add_rotor_position_ = add_rotor_position;
+        add_rotor_position_changed_ = true;
+    }
+}
+double TalonFXProSimCommand::getAddRotorPosition(void) const
+{
+    return add_rotor_position_;
+}
+bool TalonFXProSimCommand::addPositionChanged(double &add_rotor_position)
+{
+    add_rotor_position = add_rotor_position_;
+    const bool rc = add_rotor_position_changed_;
+    add_rotor_position_changed_ = false;
+    return rc;
+}
+void TalonFXProSimCommand::resetAddRotorPosition(void)
+{
+    add_rotor_position_changed_ = true;
+}
+
+void TalonFXProSimCommand::setRotorVelocity(const double rotor_velocity)
+{
+    if (rotor_velocity != rotor_velocity_)
+    {
+        rotor_velocity_ = rotor_velocity;
+        rotor_velocity_changed_ = true;
+    }
+}
+double TalonFXProSimCommand::getRotorVelocity(void) const
+{
+    return rotor_velocity_;
+}
+bool TalonFXProSimCommand::rotorVelocityChanged(double &rotor_velocity)
+{
+    rotor_velocity = rotor_velocity_;
+    const bool rc = rotor_velocity_changed_;
+    rotor_velocity_changed_ = false;
+    return rc;
+}
+void TalonFXProSimCommand::resetRotorVelocity(void)
+{
+    rotor_velocity_changed_ = true;
+}
+
+void TalonFXProSimCommand::setRotorAcceleration(const double acceleration)
+{
+    if (acceleration != rotor_acceleration_)
+    {
+        rotor_acceleration_ = acceleration;
+        rotor_acceleration_changed_ = true;
+    }
+}
+double TalonFXProSimCommand::getRotorAcceleration(void) const
+{
+    return rotor_acceleration_;
+}
+bool TalonFXProSimCommand::accelerationChanged(double &acceleration)
+{
+    acceleration = rotor_acceleration_;
+    const bool rc = rotor_acceleration_changed_;
+    rotor_acceleration_changed_ = false;
+    return rc;
+}
+void TalonFXProSimCommand::resetRotorAcceleration(void)
+{
+    rotor_acceleration_changed_ = true;
+}
+
+} // namespace hardware_interface::talonfxpro

--- a/zebROS_ws/src/ros_control_boilerplate/CMakeLists.txt
+++ b/zebROS_ws/src/ros_control_boilerplate/CMakeLists.txt
@@ -152,6 +152,7 @@ add_library(frc_robot_interface STATIC
 	src/servo_devices.cpp
 	src/solenoid_device.cpp
 	src/solenoid_devices.cpp
+	src/talonfxpro_device.cpp
 	src/talon_orchestra_device.cpp
 	src/talon_orchestra_devices.cpp
 )

--- a/zebROS_ws/src/ros_control_boilerplate/CMakeLists.txt
+++ b/zebROS_ws/src/ros_control_boilerplate/CMakeLists.txt
@@ -109,8 +109,6 @@ add_library(frc_robot_interface STATIC
     src/analog_input_device.cpp
 	src/analog_input_devices.cpp
 	src/AS726x.cpp
-	src/cancoder_device.cpp
-	src/cancoder_devices.cpp
 	src/canifier_device.cpp
 	src/canifier_devices.cpp
 	src/can_bus_status_device.cpp
@@ -170,6 +168,7 @@ add_dependencies(frc_robot_interface
 set (FRCROBOT_HW_MAIN_SRCS 
 	src/frc_robot_interface_hw.cpp
 	src/as726x_hw_device.cpp
+	src/cancoder_hw_device.cpp
 	src/candle_hw_device.cpp
 	src/ctre_v5_motor_controller_hw_device.cpp
 	src/error_queue.cpp
@@ -455,6 +454,7 @@ if (NOT (("${ARM_PREFIX}" STREQUAL "arm-frc2024-linux-gnueabi") OR
 		src/frcrobot_sim_main.cpp
 		src/frc_robot_interface_sim.cpp
 		src/as726x_sim_device.cpp
+		src/cancoder_sim_device.cpp
 		src/candle_sim_device.cpp
 		src/ctre_v5_motor_controller_sim_device.cpp
 		src/frcrobot_sim_interface.cpp
@@ -513,6 +513,8 @@ if (NOT (("${ARM_PREFIX}" STREQUAL "arm-frc2024-linux-gnueabi") OR
 		src/frcrobot_gazebosim_interface.cpp
 		src/frc_robot_interface_sim.cpp
 		src/as726x_sim_device.cpp
+		src/cancoder_sim_device.cpp
+		src/candle_sim_device.cpp
 		src/ctre_v5_motor_controller_sim_device.cpp
 		src/frcrobot_sim_interface.cpp
 		src/dummy_powerdistribution.cpp

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/cancoder_device.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/cancoder_device.h
@@ -45,7 +45,8 @@ public:
     void read(const ros::Time &time, const ros::Duration &period);
     void write(const ros::Time &time, const ros::Duration &period);
 
-    void simRead(const ros::Time &time, Tracer &tracer);
+    // Code responsible for writing changes queued in sim_command_ to the actual CTRE simulation code
+    void simWrite(const ros::Time &time, Tracer &tracer);
 
 private:
     const bool local_hardware_;

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/cancoder_device.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/cancoder_device.h
@@ -20,6 +20,7 @@ namespace hardware_interface::cancoder
 }
 class Tracer;
 
+template <bool SIM>
 class CANCoderDevice : public CTREV6Device
 {
 public:
@@ -39,9 +40,12 @@ public:
 
     void registerInterfaces(hardware_interface::cancoder::CANCoderStateInterface &state_interface,
                             hardware_interface::cancoder::CANCoderCommandInterface &command_interface,
-                            hardware_interface::cancoder::RemoteCANcoderStateInterface &remote_state_interface) const;
+                            hardware_interface::cancoder::RemoteCANcoderStateInterface &remote_state_interface,
+                            hardware_interface::cancoder::CANCoderSimCommandInterface &sim_interface) const;
     void read(const ros::Time &time, const ros::Duration &period);
     void write(const ros::Time &time, const ros::Duration &period);
+
+    void simRead(const ros::Time &time, Tracer &tracer);
 
 private:
     const bool local_hardware_;
@@ -51,6 +55,14 @@ private:
 
     std::unique_ptr<hardware_interface::cancoder::CANCoderHWState> state_;
     std::unique_ptr<hardware_interface::cancoder::CANCoderHWCommand> command_{std::make_unique<hardware_interface::cancoder::CANCoderHWCommand>()};
+    // Only instantiate the sim command interface if SIM is true
+    struct HwFields {};
+    struct SimFields
+    {
+        // TODO : defer init in hopes of not having to include corresponding .h here and in devices
+        std::unique_ptr<hardware_interface::cancoder::CANCoderSimCommand> command_sim_{std::make_unique<hardware_interface::cancoder::CANCoderSimCommand>()};
+    };
+    std::conditional_t<SIM, SimFields, HwFields> sim_fields_{};
 
     std::unique_ptr<hardware_interface::cancoder::CANCoderHWState> read_thread_state_{};
     std::unique_ptr<std::mutex> read_state_mutex_{};

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/cancoder_devices.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/cancoder_devices.h
@@ -34,16 +34,18 @@ public:
     void read(const ros::Time& time, const ros::Duration& period, Tracer &tracer) override;
     void write(const ros::Time& time, const ros::Duration& period, Tracer &tracer) override;
 
-    void simPostRead(const ros::Time& time, const ros::Duration& /*period*/, Tracer& tracer) override;
     void appendDeviceMap(std::multimap<std::string, ctre::phoenix6::hardware::ParentDevice *> &device_map) const;
+
+    // Sim-only functions below
+    void simPostRead(const ros::Time &time, const ros::Duration & /*period*/, Tracer &tracer) override;
 
 private:
     double read_hz_{100};
     std::vector<std::unique_ptr<CANCoderDevice<SIM>>> devices_;
-    std::unique_ptr<hardware_interface::cancoder::CANCoderStateInterface> state_interface_;
-    std::unique_ptr<hardware_interface::cancoder::CANCoderCommandInterface> command_interface_;
-    std::unique_ptr<hardware_interface::cancoder::RemoteCANcoderStateInterface> remote_state_interface_;
-    std::unique_ptr<hardware_interface::cancoder::CANCoderSimCommandInterface> command_sim_interface_;
+    std::unique_ptr<hardware_interface::cancoder::CANCoderStateInterface> state_interface_{std::make_unique<hardware_interface::cancoder::CANCoderStateInterface>()};
+    std::unique_ptr<hardware_interface::cancoder::CANCoderCommandInterface> command_interface_{std::make_unique<hardware_interface::cancoder::CANCoderCommandInterface>()};
+    std::unique_ptr<hardware_interface::cancoder::RemoteCANcoderStateInterface> remote_state_interface_{std::make_unique<hardware_interface::cancoder::RemoteCANcoderStateInterface>()};
+    std::unique_ptr<hardware_interface::cancoder::CANCoderSimCommandInterface> command_sim_interface_{std::make_unique<hardware_interface::cancoder::CANCoderSimCommandInterface>()};
     hardware_interface::InterfaceManager interface_manager_;
 };
 

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/cancoder_devices.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/cancoder_devices.h
@@ -45,7 +45,7 @@ private:
     std::unique_ptr<hardware_interface::cancoder::CANCoderStateInterface> state_interface_{std::make_unique<hardware_interface::cancoder::CANCoderStateInterface>()};
     std::unique_ptr<hardware_interface::cancoder::CANCoderCommandInterface> command_interface_{std::make_unique<hardware_interface::cancoder::CANCoderCommandInterface>()};
     std::unique_ptr<hardware_interface::cancoder::RemoteCANcoderStateInterface> remote_state_interface_{std::make_unique<hardware_interface::cancoder::RemoteCANcoderStateInterface>()};
-    std::unique_ptr<hardware_interface::cancoder::CANCoderSimCommandInterface> command_sim_interface_{std::make_unique<hardware_interface::cancoder::CANCoderSimCommandInterface>()};
+    std::unique_ptr<hardware_interface::cancoder::CANCoderSimCommandInterface> sim_command_interface_{std::make_unique<hardware_interface::cancoder::CANCoderSimCommandInterface>()};
     hardware_interface::InterfaceManager interface_manager_;
 };
 

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/cancoder_devices.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/cancoder_devices.h
@@ -4,12 +4,13 @@
 #include <map>
 #include "ros_control_boilerplate/devices.h"
 
-class CANCoderDevice;
+template <bool SIM> class CANCoderDevice;
 namespace hardware_interface::cancoder
 {
     class CANCoderStateInterface;
     class CANCoderCommandInterface;
     class RemoteCANcoderStateInterface;
+    class CANCoderSimCommandInterface;
 }
 
 namespace ctre::phoenix6::hardware
@@ -17,6 +18,7 @@ namespace ctre::phoenix6::hardware
     class ParentDevice;
 }
 
+template <bool SIM>
 class CANCoderDevices : public Devices
 {
 public:
@@ -32,14 +34,16 @@ public:
     void read(const ros::Time& time, const ros::Duration& period, Tracer &tracer) override;
     void write(const ros::Time& time, const ros::Duration& period, Tracer &tracer) override;
 
+    void simPostRead(const ros::Time& time, const ros::Duration& /*period*/, Tracer& tracer) override;
     void appendDeviceMap(std::multimap<std::string, ctre::phoenix6::hardware::ParentDevice *> &device_map) const;
 
 private:
     double read_hz_{100};
-    std::vector<std::unique_ptr<CANCoderDevice>> devices_;
+    std::vector<std::unique_ptr<CANCoderDevice<SIM>>> devices_;
     std::unique_ptr<hardware_interface::cancoder::CANCoderStateInterface> state_interface_;
     std::unique_ptr<hardware_interface::cancoder::CANCoderCommandInterface> command_interface_;
     std::unique_ptr<hardware_interface::cancoder::RemoteCANcoderStateInterface> remote_state_interface_;
+    std::unique_ptr<hardware_interface::cancoder::CANCoderSimCommandInterface> command_sim_interface_;
     hardware_interface::InterfaceManager interface_manager_;
 };
 

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/devices.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/devices.h
@@ -18,6 +18,7 @@
 #define INC_DEVICES_H__
 
 #include <ros/ros.h>
+#include <hardware_interface/robot_hw.h>
 #include "ros_control_boilerplate/tracer.h"
 
 namespace hardware_interface
@@ -62,6 +63,8 @@ public:
     virtual void hwRead(const ros::Time& /*time*/, const ros::Duration& /*period*/, Tracer& /*tracer*/) {}
     virtual void hwWrite(const ros::Time& /*time*/, const ros::Duration& /*period*/, Tracer& /*tracer*/) {}
 
+    static void setRobotHW(hardware_interface::RobotHW *robot_hw) { robot_hw_ = robot_hw; }
+
     // Used to signal that all controllers are finished loading
     static void signalReady(void) { ready_ = true; }
 
@@ -73,11 +76,13 @@ protected:
     static bool isEnabled(void)  { return enabled_; }
     static bool isHALRobot(void) { return hal_robot_; }
     static bool isReady(void)    { return ready_; }
+    static hardware_interface::RobotHW *getRobotHW(void) { return robot_hw_; }
 
 private:
     static inline bool enabled_{true};
     static inline bool hal_robot_{true};
     static inline bool ready_{false};
+    static inline hardware_interface::RobotHW *robot_hw_{nullptr};
 };
 
 template<class T>

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/devices.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/devices.h
@@ -18,12 +18,12 @@
 #define INC_DEVICES_H__
 
 #include <ros/ros.h>
-#include <hardware_interface/robot_hw.h>
 #include "ros_control_boilerplate/tracer.h"
 
 namespace hardware_interface
 {
     class InterfaceManager;
+    class RobotHW;
 }
 
 namespace gazebo::physics

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/sim_talonfxpro_device.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/sim_talonfxpro_device.h
@@ -12,6 +12,13 @@ namespace gazebo::physics
     class Model;
 }
 
+namespace hardware_interface::talonfxpro
+{
+    class TalonFXProSimCommand;
+    class TalonFXProSimCommandInterface;
+    class TalonFXProStateInterface;
+}
+
 class SimTalonFXProDevice : public TalonFXProDevice
 {
 public:
@@ -28,8 +35,14 @@ public:
     SimTalonFXProDevice &operator=(const SimTalonFXProDevice &) = delete;
     SimTalonFXProDevice &operator=(SimTalonFXProDevice &&) noexcept = delete;
 
+    void registerSimInterface(hardware_interface::talonfxpro::TalonFXProStateInterface &state_interface,
+                              hardware_interface::talonfxpro::TalonFXProSimCommandInterface &sim_command_interface) const;
+
     // Read and write functions which add additional sim features
     void simRead(const ros::Time& time, const ros::Duration& period, hardware_interface::cancoder::CANCoderSimCommandInterface *sim_cancoder_if);
+
+    // Write commands queued in sim_command_ to the simulated TalonFXPro CTRE libs
+    void simWrite(const ros::Time& time, const ros::Duration& period);
 
     bool setSimLimitSwitches(const bool forward_limit, const bool reverse_limit);
     bool setSimCurrent(const double stator_current, const double supply_current);
@@ -38,9 +51,10 @@ public:
 
 private:
     boost::shared_ptr<gazebo::physics::Joint> gazebo_joint_;
-    // int counter_{0};
     std::optional<int> cancoder_id_;
     hardware_interface::cancoder::CANCoderSimCommandHandle cancoder_;
+
+    std::unique_ptr<hardware_interface::talonfxpro::TalonFXProSimCommand> sim_command_{std::make_unique<hardware_interface::talonfxpro::TalonFXProSimCommand>()};
 };
 
 #endif

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/sim_talonfxpro_device.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/sim_talonfxpro_device.h
@@ -1,12 +1,10 @@
 #ifndef SIM_TALONFXPRO_DEVICE_INC__
 #define SIM_TALONFXPRO_DEVICE_INC__
 
-#include "ros_control_boilerplate/talonfxpro_device.h"
+#include <optional>
 
-namespace ctre::phoenix6::hardware::core
-{
-    class CoreCANcoder;
-}
+#include "ros_control_boilerplate/talonfxpro_device.h"
+#include "ctre_interfaces/cancoder_sim_command_interface.h"
 
 namespace gazebo::physics
 {
@@ -31,16 +29,18 @@ public:
     SimTalonFXProDevice &operator=(SimTalonFXProDevice &&) noexcept = delete;
 
     // Read and write functions which add additional sim features
-    void simRead(const ros::Time& time, const ros::Duration& period);
+    void simRead(const ros::Time& time, const ros::Duration& period, hardware_interface::cancoder::CANCoderSimCommandInterface *sim_cancoder_if);
 
     bool setSimLimitSwitches(const bool forward_limit, const bool reverse_limit);
     bool setSimCurrent(const double stator_current, const double supply_current);
 
     bool gazeboInit(boost::shared_ptr<gazebo::physics::Model> parent_model);
+
 private:
     boost::shared_ptr<gazebo::physics::Joint> gazebo_joint_;
     // int counter_{0};
-    std::unique_ptr<ctre::phoenix6::hardware::core::CoreCANcoder> cancoder_;
+    std::optional<int> cancoder_id_;
+    hardware_interface::cancoder::CANCoderSimCommandHandle cancoder_;
 };
 
 #endif

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/talonfxpro_devices.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/talonfxpro_devices.h
@@ -35,13 +35,15 @@ public:
     void read(const ros::Time& time, const ros::Duration& period, Tracer &tracer) override;
     void write(const ros::Time& time, const ros::Duration& period, Tracer &tracer) override;
 
+    void appendDeviceMap(std::multimap<std::string, ctre::phoenix6::hardware::ParentDevice *> &device_map) const;
+
+    // Sim-only functions below
     void simInit(ros::NodeHandle &nh) override;
+
     // simRead hooks up to CTRE simulation code and updates motor state each control cycle
     void simPreRead(const ros::Time &time, const ros::Duration &period, Tracer &tracer) override;
 
     bool gazeboSimInit(const ros::NodeHandle &/*nh*/, boost::shared_ptr<gazebo::physics::Model> parent_model) override;
-
-    void appendDeviceMap(std::multimap<std::string, ctre::phoenix6::hardware::ParentDevice *> &device_map) const;
 
 private:
     using DEVICE_TYPE = std::conditional_t<SIM, SimTalonFXProDevice, TalonFXProDevice>;
@@ -51,18 +53,24 @@ private:
     hardware_interface::InterfaceManager interface_manager_;
     double read_hz_{100.};
 
+    // Set this to true so the first time through ::write there will
+    // be a forced true->false transition. This will be used to force the
+    // devices into a disabled state.
+    bool prev_robot_enabled_{true};
+    
+    // Sim-only functions below
     bool setlimit(ros_control_boilerplate::set_limit_switch::Request &req,
                   ros_control_boilerplate::set_limit_switch::Response &res);
     bool setcurrent(ros_control_boilerplate::set_current::Request &req,
                     ros_control_boilerplate::set_current::Response &res);
 
-    ros::ServiceServer sim_limit_switch_srv_;
-    ros::ServiceServer sim_current_srv_;
-
-    // Set this to true so the first time through ::write there will
-    // be a forced true->false transition. This will be used to force the
-    // devices into a disabled state.
-    bool prev_robot_enabled_{true};
+    struct HwFields {};
+    struct SimFields
+    {
+        ros::ServiceServer sim_limit_switch_srv_;
+        ros::ServiceServer sim_current_srv_;
+    };
+    std::conditional_t<SIM, SimFields, HwFields> sim_fields_{};
 };
 
 #endif

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/talonfxpro_devices.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/talonfxpro_devices.h
@@ -12,6 +12,7 @@ namespace hardware_interface::talonfxpro
 {
     class TalonFXProStateInterface;
     class TalonFXProCommandInterface;
+    class TalonFXProSimCommandInterface;
 }
 
 namespace ctre::phoenix6::hardware
@@ -40,8 +41,9 @@ public:
     // Sim-only functions below
     void simInit(ros::NodeHandle &nh) override;
 
-    // simRead hooks up to CTRE simulation code and updates motor state each control cycle
     void simPreRead(const ros::Time &time, const ros::Duration &period, Tracer &tracer) override;
+    // simPostRead is responsible for writing changes to the actual CTRE simulation code
+    void simPostRead(const ros::Time &time, const ros::Duration &period, Tracer &tracer) override;
 
     bool gazeboSimInit(const ros::NodeHandle &/*nh*/, boost::shared_ptr<gazebo::physics::Model> parent_model) override;
 
@@ -69,6 +71,7 @@ private:
     {
         ros::ServiceServer sim_limit_switch_srv_;
         ros::ServiceServer sim_current_srv_;
+        std::unique_ptr<hardware_interface::talonfxpro::TalonFXProSimCommandInterface> sim_command_interface_;
     };
     std::conditional_t<SIM, SimFields, HwFields> sim_fields_{};
 };

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/talonfxpro_devices.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/talonfxpro_devices.h
@@ -71,7 +71,7 @@ private:
     {
         ros::ServiceServer sim_limit_switch_srv_;
         ros::ServiceServer sim_current_srv_;
-        std::unique_ptr<hardware_interface::talonfxpro::TalonFXProSimCommandInterface> sim_command_interface_;
+        std::unique_ptr<hardware_interface::talonfxpro::TalonFXProSimCommandInterface> sim_command_interface_{std::make_unique<hardware_interface::talonfxpro::TalonFXProSimCommandInterface>()};
     };
     std::conditional_t<SIM, SimFields, HwFields> sim_fields_{};
 };

--- a/zebROS_ws/src/ros_control_boilerplate/src/cancoder_device.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/cancoder_device.cpp
@@ -3,24 +3,28 @@
 #include "ctre/phoenix6/core/CoreCANcoder.hpp"
 
 #include "ctre_interfaces/cancoder_command_interface.h"
+#include "ctre_interfaces/cancoder_sim_command_interface.h" // TODO - split sim into derived class so this isn't included in HW code?
 #include "ros_control_boilerplate/cancoder_device.h"
 #include "ros_control_boilerplate/tracer.h"
 
-static bool convertMagnetHealth(const ctre::phoenix6::signals::MagnetHealthValue & input,
-                                       hardware_interface::cancoder::MagnetHealth &output);
+static bool convertMagnetHealth(const ctre::phoenix6::signals::MagnetHealthValue &input,
+                                hardware_interface::cancoder::MagnetHealth &output);
+static bool convertMagnetHealth(const hardware_interface::cancoder::MagnetHealth input,
+                                ctre::phoenix6::signals::MagnetHealthValue &output);
 static bool convertSensorDirection(hardware_interface::cancoder::SensorDirection input,
                                    ctre::phoenix6::signals::SensorDirectionValue &output);
 static bool convertAbsoluteSensorRange(hardware_interface::cancoder::AbsoluteSensorRange input,
                                        ctre::phoenix6::signals::AbsoluteSensorRangeValue &output);
 
-CANCoderDevice::CANCoderDevice(const std::string &name_space,
-                               const int joint_index,
-                               const std::string &joint_name,
-                               const int can_id,
-                               const std::string &can_bus,
-                               const bool local_hardware,
-                               const bool local_update,
-                               const double read_hz_)
+template <bool SIM>
+CANCoderDevice<SIM>::CANCoderDevice(const std::string &name_space,
+                                    const int joint_index,
+                                    const std::string &joint_name,
+                                    const int can_id,
+                                    const std::string &can_bus,
+                                    const bool local_hardware,
+                                    const bool local_update,
+                                    const double read_hz_)
     : CTREV6Device("CANcoder", joint_name, can_id)
     , local_hardware_{local_hardware}
     , local_update_{local_update}
@@ -38,17 +42,20 @@ CANCoderDevice::CANCoderDevice(const std::string &name_space,
         setParentDevice(cancoder_.get());
         read_thread_state_ = std::make_unique<hardware_interface::cancoder::CANCoderHWState>(can_id);
         read_state_mutex_ = std::make_unique<std::mutex>();
-        read_thread_ = std::make_unique<std::jthread>(&CANCoderDevice::read_thread, this,
+        read_thread_ = std::make_unique<std::jthread>(&CANCoderDevice<SIM>::read_thread, this,
                                                       std::make_unique<Tracer>("cancoder_read_" + joint_name + " " + name_space),
                                                       read_hz_);
     }
 }
 
-CANCoderDevice::~CANCoderDevice(void) = default;
+template <bool SIM>
+CANCoderDevice<SIM>::~CANCoderDevice(void) = default;
 
-void CANCoderDevice::registerInterfaces(hardware_interface::cancoder::CANCoderStateInterface &state_interface,
-                                        hardware_interface::cancoder::CANCoderCommandInterface &command_interface,
-                                        hardware_interface::cancoder::RemoteCANcoderStateInterface &remote_state_interface) const
+template <bool SIM>
+void CANCoderDevice<SIM>::registerInterfaces(hardware_interface::cancoder::CANCoderStateInterface &state_interface,
+                                             hardware_interface::cancoder::CANCoderCommandInterface &command_interface,
+                                             hardware_interface::cancoder::RemoteCANcoderStateInterface &remote_state_interface,
+                                             hardware_interface::cancoder::CANCoderSimCommandInterface &command_sim_interface) const
 {
     ROS_INFO_STREAM("FRCRobotInterface: Registering interface for CANCoder : " << getName() << " at CAN id " << getId());
 
@@ -63,9 +70,16 @@ void CANCoderDevice::registerInterfaces(hardware_interface::cancoder::CANCoderSt
         hardware_interface::cancoder::CANCoderWritableStateHandle remote_handle(getName(), state_.get());
         remote_state_interface.registerHandle(remote_handle);
     }
+
+    if constexpr (SIM)
+    {
+        hardware_interface::cancoder::CANCoderSimCommandHandle command_sim_handle(state_handle, sim_fields_.command_sim_.get());
+        command_sim_interface.registerHandle(command_sim_handle);
+    }
 }
 
-void CANCoderDevice::read(const ros::Time &/*time*/, const ros::Duration &/*period*/)
+template <bool SIM>
+void CANCoderDevice<SIM>::read(const ros::Time &/*time*/, const ros::Duration &/*period*/)
 {
     if (local_update_)
     {
@@ -105,7 +119,8 @@ void CANCoderDevice::read(const ros::Time &/*time*/, const ros::Duration &/*peri
     }
 }
 
-void CANCoderDevice::write(const ros::Time &/*time*/, const ros::Duration &/*period*/)
+template <bool SIM>
+void CANCoderDevice<SIM>::write(const ros::Time &/*time*/, const ros::Duration &/*period*/)
 {
     if (!local_hardware_)
     {
@@ -196,8 +211,9 @@ signals.push_back(&var##_signal);
 const auto var = safeRead(var##_signal, #function); \
 if (!var) { tracer->stop() ; continue; }
 
-void CANCoderDevice::read_thread(std::unique_ptr<Tracer> tracer,
-                                 const double poll_frequency)
+template <bool SIM>
+void CANCoderDevice<SIM>::read_thread(std::unique_ptr<Tracer> tracer,
+                                      const double poll_frequency)
 {
 #ifdef __linux__
     std::stringstream thread_name{"cancdr_rd_"};
@@ -332,7 +348,7 @@ void CANCoderDevice::read_thread(std::unique_ptr<Tracer> tracer,
 	}
 }
 
-static bool convertMagnetHealth(const ctre::phoenix6::signals::MagnetHealthValue & input,
+static bool convertMagnetHealth(const ctre::phoenix6::signals::MagnetHealthValue &input,
                                 hardware_interface::cancoder::MagnetHealth &output)
 {
     switch (input.value)
@@ -350,12 +366,35 @@ static bool convertMagnetHealth(const ctre::phoenix6::signals::MagnetHealthValue
         output = hardware_interface::cancoder::MagnetHealth::Green;
         break;
     default:
-        ROS_ERROR("Invalid input in convertCANCoderMagnetFieldStrength");
+        ROS_ERROR("Invalid input in convertMagentHealth");
         return false;
     }
     return true;
 }
 
+static bool convertMagnetHealth(const hardware_interface::cancoder::MagnetHealth input,
+                                ctre::phoenix6::signals::MagnetHealthValue &output)
+{
+    switch (input)
+    {
+    case hardware_interface::cancoder::MagnetHealth::Invalid:
+        output.value = ctre::phoenix6::signals::MagnetHealthValue::Magnet_Invalid;
+        break;
+    case hardware_interface::cancoder::MagnetHealth::Red:
+        output.value = ctre::phoenix6::signals::MagnetHealthValue::Magnet_Red;
+        break;
+    case hardware_interface::cancoder::MagnetHealth::Orange:
+        output.value = ctre::phoenix6::signals::MagnetHealthValue::Magnet_Orange;
+        break;
+    case hardware_interface::cancoder::MagnetHealth::Green:
+        output.value = ctre::phoenix6::signals::MagnetHealthValue::Magnet_Green;
+        break;
+    default:
+        ROS_ERROR("Invalid input in convertMagnetHealth");
+        return false;
+    }
+    return true;
+}
 static bool convertSensorDirection(hardware_interface::cancoder::SensorDirection input,
                                    ctre::phoenix6::signals::SensorDirectionValue &output)
 {
@@ -389,4 +428,88 @@ static bool convertAbsoluteSensorRange(hardware_interface::cancoder::AbsoluteSen
         return false;
     }
     return true;
+}
+
+template <bool SIM>
+void CANCoderDevice<SIM>::simRead(const ros::Time &time, Tracer &tracer)
+{
+    if constexpr (SIM)
+    {
+        tracer.start_unique("cancoder_sim_read");
+        if (!local_hardware_)
+        {
+            return;
+        }
+
+        auto &sim_collection = cancoder_->GetSimState();
+
+        if (double supply_voltage; sim_fields_.command_sim_->supplyVoltageChanged(supply_voltage))
+        {
+            if (safeCall(sim_collection.SetSupplyVoltage(units::volt_t{supply_voltage}), "cancoder sim->SetSupplyVoltage"))
+            {
+                // ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Set position to " << position);
+                // Don't set state - it will be updated in next read() loop
+            }
+            else
+            {
+                sim_fields_.command_sim_->resetSupplyVoltage();
+                return;
+            }
+        }
+        if (double raw_position; sim_fields_.command_sim_->rawPositionChanged(raw_position))
+        {
+            if (safeCall(sim_collection.SetRawPosition(units::radian_t{raw_position}), "cancoder sim->SetRawPosition"))
+            {
+                // ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Set position to " << position);
+                // Don't set state - it will be updated in next read() loop
+            }
+            else
+            {
+                sim_fields_.command_sim_->resetRawPosition();
+                return;
+            }
+        }
+        if (double add_position; sim_fields_.command_sim_->addPositionChanged(add_position))
+        {
+            if (safeCall(sim_collection.AddPosition(units::radian_t{add_position}), "cancoder sim->AddPosition"))
+            {
+                // ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Set position to " << position);
+                // Don't set state - it will be updated in next read() loop
+            }
+            else
+            {
+                sim_fields_.command_sim_->resetAddPosition();
+                return;
+            }
+        }
+        if (double velocity; sim_fields_.command_sim_->velocityChanged(velocity))
+        {
+            if (safeCall(sim_collection.SetVelocity(units::radians_per_second_t{velocity}), "cancoder sim->SetVelocity"))
+            {
+                // ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Set position to " << position);
+                // Don't set state - it will be updated in next read() loop
+            }
+            else
+            {
+                sim_fields_.command_sim_->resetVelocity();
+                return;
+            }
+        }
+        if (hardware_interface::cancoder::MagnetHealth magnet_health_hwi; sim_fields_.command_sim_->magnetHealthChanged(magnet_health_hwi))
+        {
+            ctre::phoenix6::signals::MagnetHealthValue magnet_health_ctre;
+            if (convertMagnetHealth(magnet_health_hwi, magnet_health_ctre))
+            {
+                if (safeCall(sim_collection.SetMagnetHealth(magnet_health_ctre), "cancoder sim->SetMagnetHealth"))
+                {
+                    // Don't set state - it will be updated in next read() loop
+                }
+                else
+                {
+                    sim_fields_.command_sim_->resetMagnetHealth();
+                    return;
+                }
+            }
+        }
+    }
 }

--- a/zebROS_ws/src/ros_control_boilerplate/src/cancoder_device.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/cancoder_device.cpp
@@ -447,7 +447,7 @@ void CANCoderDevice<SIM>::simWrite(const ros::Time &time, Tracer &tracer)
         {
             if (safeCall(sim_collection.SetSupplyVoltage(units::volt_t{supply_voltage}), "cancoder sim->SetSupplyVoltage"))
             {
-                // ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Set position to " << position);
+                ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Set supply voltage to " << supply_voltage);
                 // Don't set state - it will be updated in next read() loop
             }
             else
@@ -458,9 +458,10 @@ void CANCoderDevice<SIM>::simWrite(const ros::Time &time, Tracer &tracer)
         }
         if (double raw_position; sim_fields_.command_sim_->rawPositionChanged(raw_position))
         {
+            ROS_INFO_STREAM("CANCoderDevice::simWrite raw_position: " << raw_position);
             if (safeCall(sim_collection.SetRawPosition(units::radian_t{raw_position}), "cancoder sim->SetRawPosition"))
             {
-                // ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Set position to " << position);
+                ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Set raw position to " << raw_position);
                 // Don't set state - it will be updated in next read() loop
             }
             else
@@ -473,7 +474,7 @@ void CANCoderDevice<SIM>::simWrite(const ros::Time &time, Tracer &tracer)
         {
             if (safeCall(sim_collection.AddPosition(units::radian_t{add_position}), "cancoder sim->AddPosition"))
             {
-                // ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Set position to " << position);
+                ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Adding position " << add_position);
                 // Don't set state - it will be updated in next read() loop
             }
             else
@@ -486,7 +487,7 @@ void CANCoderDevice<SIM>::simWrite(const ros::Time &time, Tracer &tracer)
         {
             if (safeCall(sim_collection.SetVelocity(units::radians_per_second_t{velocity}), "cancoder sim->SetVelocity"))
             {
-                // ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Set position to " << position);
+                ROS_INFO_STREAM("CANcoder id = " << getId() << " = " << getName() << " : Set velocity to " << velocity);
                 // Don't set state - it will be updated in next read() loop
             }
             else

--- a/zebROS_ws/src/ros_control_boilerplate/src/cancoder_device.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/cancoder_device.cpp
@@ -55,7 +55,7 @@ template <bool SIM>
 void CANCoderDevice<SIM>::registerInterfaces(hardware_interface::cancoder::CANCoderStateInterface &state_interface,
                                              hardware_interface::cancoder::CANCoderCommandInterface &command_interface,
                                              hardware_interface::cancoder::RemoteCANcoderStateInterface &remote_state_interface,
-                                             hardware_interface::cancoder::CANCoderSimCommandInterface &command_sim_interface) const
+                                             hardware_interface::cancoder::CANCoderSimCommandInterface &sim_command_interface) const
 {
     ROS_INFO_STREAM("FRCRobotInterface: Registering interface for CANCoder : " << getName() << " at CAN id " << getId());
 
@@ -74,7 +74,7 @@ void CANCoderDevice<SIM>::registerInterfaces(hardware_interface::cancoder::CANCo
     if constexpr (SIM)
     {
         hardware_interface::cancoder::CANCoderSimCommandHandle command_sim_handle(state_handle, sim_fields_.command_sim_.get());
-        command_sim_interface.registerHandle(command_sim_handle);
+        sim_command_interface.registerHandle(command_sim_handle);
     }
 }
 
@@ -431,7 +431,7 @@ static bool convertAbsoluteSensorRange(hardware_interface::cancoder::AbsoluteSen
 }
 
 template <bool SIM>
-void CANCoderDevice<SIM>::simRead(const ros::Time &time, Tracer &tracer)
+void CANCoderDevice<SIM>::simWrite(const ros::Time &time, Tracer &tracer)
 {
     if constexpr (SIM)
     {

--- a/zebROS_ws/src/ros_control_boilerplate/src/cancoder_device.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/cancoder_device.cpp
@@ -224,7 +224,7 @@ void CANCoderDevice<SIM>::read_thread(std::unique_ptr<Tracer> tracer,
 	}
 #endif
 	ros::Duration(2.452 + read_thread_state_->getDeviceNumber() * 0.07).sleep(); // Sleep for a few seconds to let CAN start up
-    ROS_INFO_STREAM("Starting CANCoder read thead for " << getName() << " id = " << getId());
+    ROS_INFO_STREAM("Starting CANCoder read thread for " << getName() << " id = " << getId());
 
     std::vector<ctre::phoenix6::BaseStatusSignal *> signals;
 

--- a/zebROS_ws/src/ros_control_boilerplate/src/cancoder_devices.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/cancoder_devices.cpp
@@ -1,10 +1,12 @@
 #include <hardware_interface/robot_hw.h> // for hardware_interface::InterfaceManager
 #include "ctre_interfaces/cancoder_command_interface.h"
+#include "ctre_interfaces/cancoder_sim_command_interface.h"
 #include "ros_control_boilerplate/cancoder_devices.h"
 #include "ros_control_boilerplate/cancoder_device.h"
 #include "ros_control_boilerplate/read_config_utils.h"
 
-CANCoderDevices::CANCoderDevices(ros::NodeHandle &root_nh)
+template <bool SIM>
+CANCoderDevices<SIM>::CANCoderDevices(ros::NodeHandle &root_nh)
     : state_interface_{std::make_unique<hardware_interface::cancoder::CANCoderStateInterface>()}
     , command_interface_{std::make_unique<hardware_interface::cancoder::CANCoderCommandInterface>()}
     , remote_state_interface_{std::make_unique<hardware_interface::cancoder::RemoteCANcoderStateInterface>()}
@@ -54,26 +56,30 @@ CANCoderDevices::CANCoderDevices(ros::NodeHandle &root_nh)
 				throw std::runtime_error("A CANCoder can_bus was specified with local_hardware == false for joint " + joint_name);
             }
 
-            devices_.emplace_back(std::make_unique<CANCoderDevice>(root_nh.getNamespace(), i, joint_name, can_id, can_bus, local_update, local_hardware, read_hz_));
+            devices_.emplace_back(std::make_unique<CANCoderDevice<SIM>>(root_nh.getNamespace(), i, joint_name, can_id, can_bus, local_update, local_hardware, read_hz_));
         }
     }
 }
 
-CANCoderDevices::~CANCoderDevices() = default;
+template <bool SIM>
+CANCoderDevices<SIM>::~CANCoderDevices() = default;
 
-hardware_interface::InterfaceManager *CANCoderDevices::registerInterface()
+template <bool SIM>
+hardware_interface::InterfaceManager *CANCoderDevices<SIM>::registerInterface()
 {
     for (const auto &d : devices_)
     {
-        d->registerInterfaces(*state_interface_, *command_interface_, *remote_state_interface_);
+        d->registerInterfaces(*state_interface_, *command_interface_, *remote_state_interface_, *command_sim_interface_);
     }
     interface_manager_.registerInterface(state_interface_.get());
     interface_manager_.registerInterface(command_interface_.get());
     interface_manager_.registerInterface(remote_state_interface_.get());
+    interface_manager_.registerInterface(command_sim_interface_.get());
     return &interface_manager_;
 }
 
-void CANCoderDevices::read(const ros::Time& time, const ros::Duration& period, Tracer &tracer)
+template <bool SIM>
+void CANCoderDevices<SIM>::read(const ros::Time& time, const ros::Duration& period, Tracer &tracer)
 {
     tracer.start_unique("cancoder");
     for (const auto &d : devices_)
@@ -82,7 +88,8 @@ void CANCoderDevices::read(const ros::Time& time, const ros::Duration& period, T
     }
 }
 
-void CANCoderDevices::write(const ros::Time& time, const ros::Duration& period, Tracer &tracer)
+template <bool SIM>
+void CANCoderDevices<SIM>::write(const ros::Time& time, const ros::Duration& period, Tracer &tracer)
 {
     tracer.start_unique("cancoder");
     for (const auto &d : devices_)
@@ -91,7 +98,8 @@ void CANCoderDevices::write(const ros::Time& time, const ros::Duration& period, 
     }
 }
 
-void CANCoderDevices::appendDeviceMap(std::multimap<std::string, ctre::phoenix6::hardware::ParentDevice *> &device_map) const
+template <bool SIM>
+void CANCoderDevices<SIM>::appendDeviceMap(std::multimap<std::string, ctre::phoenix6::hardware::ParentDevice *> &device_map) const
 {
     for (auto &d : devices_)
     {
@@ -99,6 +107,18 @@ void CANCoderDevices::appendDeviceMap(std::multimap<std::string, ctre::phoenix6:
         if (ptr)
         {
             device_map.emplace(d->getName(), ptr);
+        }
+    }
+}
+
+template <bool SIM>
+void CANCoderDevices<SIM>::simPostRead(const ros::Time& time, const ros::Duration& /*period*/, Tracer& tracer)
+{
+    if constexpr (SIM)
+    {
+        for (auto &d : devices_)
+        {
+            d->simRead(time, tracer);
         }
     }
 }

--- a/zebROS_ws/src/ros_control_boilerplate/src/cancoder_devices.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/cancoder_devices.cpp
@@ -66,14 +66,14 @@ hardware_interface::InterfaceManager *CANCoderDevices<SIM>::registerInterface()
 {
     for (const auto &d : devices_)
     {
-        d->registerInterfaces(*state_interface_, *command_interface_, *remote_state_interface_, *command_sim_interface_);
+        d->registerInterfaces(*state_interface_, *command_interface_, *remote_state_interface_, *sim_command_interface_);
     }
     interface_manager_.registerInterface(state_interface_.get());
     interface_manager_.registerInterface(command_interface_.get());
     interface_manager_.registerInterface(remote_state_interface_.get());
     if constexpr (SIM)
     {
-        interface_manager_.registerInterface(command_sim_interface_.get());
+        interface_manager_.registerInterface(sim_command_interface_.get());
     }
     return &interface_manager_;
 }
@@ -119,7 +119,7 @@ void CANCoderDevices<SIM>::simPostRead(const ros::Time& time, const ros::Duratio
         tracer.start_unique("cancoder simPostRead");
         for (const auto &d : devices_)
         {
-            d->simRead(time, tracer);
+            d->simWrite(time, tracer);
         }
     }
 }

--- a/zebROS_ws/src/ros_control_boilerplate/src/cancoder_hw_device.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/cancoder_hw_device.cpp
@@ -1,0 +1,6 @@
+#include <hardware_interface/robot_hw.h> // for hardware_interface::InterfaceManager
+#include "../src/cancoder_devices.cpp"
+#include "../src/cancoder_device.cpp"
+
+template class CANCoderDevices<false>;
+template class CANCoderDevice<false>;

--- a/zebROS_ws/src/ros_control_boilerplate/src/cancoder_sim_device.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/cancoder_sim_device.cpp
@@ -1,0 +1,6 @@
+#include <hardware_interface/robot_hw.h> // for hardware_interface::InterfaceManager
+#include "../src/cancoder_devices.cpp"
+#include "../src/cancoder_device.cpp"
+
+template class CANCoderDevices<true>;
+template class CANCoderDevice<true>;

--- a/zebROS_ws/src/ros_control_boilerplate/src/ctre_v6_device.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/ctre_v6_device.cpp
@@ -22,7 +22,7 @@ bool CTREV6Device::safeCall(ctre::phoenix::StatusCode status_code, const std::st
         can_error_count_ = 0;
         can_error_sent_ = false;
         // Only for debugging traces of successful calls ROS_INFO_STREAM("safeCall : " << name_ << " : " << method_name);
-        ROS_INFO_STREAM("safeCall : " << name_ << " : " << method_name);
+        // ROS_INFO_STREAM("safeCall : " << name_ << " : " << method_name);
         return true; // Yay us!
     }
     ROS_ERROR_STREAM("Error : " << device_type_ << " " << name_ << " id = " << id_ << " calling " << method_name << " : " << status_code.GetName());

--- a/zebROS_ws/src/ros_control_boilerplate/src/ctre_v6_device.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/ctre_v6_device.cpp
@@ -22,6 +22,7 @@ bool CTREV6Device::safeCall(ctre::phoenix::StatusCode status_code, const std::st
         can_error_count_ = 0;
         can_error_sent_ = false;
         // Only for debugging traces of successful calls ROS_INFO_STREAM("safeCall : " << name_ << " : " << method_name);
+        ROS_INFO_STREAM("safeCall : " << name_ << " : " << method_name);
         return true; // Yay us!
     }
     ROS_ERROR_STREAM("Error : " << device_type_ << " " << name_ << " id = " << id_ << " calling " << method_name << " : " << status_code.GetName());

--- a/zebROS_ws/src/ros_control_boilerplate/src/frc_robot_interface.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frc_robot_interface.cpp
@@ -162,7 +162,7 @@ bool FRCRobotInterface<SIM>::init(ros::NodeHandle& root_nh, ros::NodeHandle &/*r
 	devices_.emplace_back(std::make_unique<AnalogInputDevices>(root_nh));
 	devices_.emplace_back(std::make_unique<AS726xDevices<SIM>>(root_nh));
 	devices_.emplace_back(std::make_unique<CANBusStatusDevices>(root_nh));
-	devices_.emplace_back(std::make_unique<CANCoderDevices>(root_nh));
+	devices_.emplace_back(std::make_unique<CANCoderDevices<SIM>>(root_nh));
 	devices_.emplace_back(std::make_unique<CANdleDevices<SIM>>(root_nh));
 	devices_.emplace_back(std::make_unique<CANifierDevices<SIM>>(root_nh));
 	devices_.emplace_back(std::make_unique<CTREV5MotorControllers<SIM>>(root_nh));
@@ -202,7 +202,7 @@ bool FRCRobotInterface<SIM>::init(ros::NodeHandle& root_nh, ros::NodeHandle &/*r
 			device_ptr->appendDeviceMap(ctrev6_devices);
 		}
 	};
-	append_device_map.template operator()<CANCoderDevices>(); // C++ 20 templated lamba call syntax is dumb if there's no function parameter to deduce the types from
+	append_device_map.template operator()<CANCoderDevices<SIM>>(); // C++ 20 templated lamba call syntax is dumb if there's no function parameter to deduce the types from
 	append_device_map.template operator()<Pigeon2Devices>();  // and apparently even dumber if they're in a templated member function
 	append_device_map.template operator()<TalonFXProDevices<SIM>>();
 	devices_.emplace_back(std::make_unique<LatencyCompensationGroups>(root_nh, ctrev6_devices));

--- a/zebROS_ws/src/ros_control_boilerplate/src/frc_robot_interface.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frc_robot_interface.cpp
@@ -146,12 +146,20 @@ bool FRCRobotInterface<SIM>::init(ros::NodeHandle& root_nh, ros::NodeHandle &/*r
 		 * but aren't using any of the CAN device classes.
 		 **/
 		ctre::phoenix::unmanaged::Unmanaged::LoadPhoenix();
+		if constexpr (SIM)
+		{
+			// Only run Phoenix tuner server on the Jetson in sim, disable it here for the Rio
+			ctre::phoenix::unmanaged::Unmanaged::SetPhoenixDiagnosticsStartTime(-1);
+		}
 
 	}
 	else
 	{
-		// Only run Phoenix tuner server on the Rio, disable it here for the Jetson
-		ctre::phoenix::unmanaged::Unmanaged::SetPhoenixDiagnosticsStartTime(-1);
+		if constexpr (!SIM)
+		{
+			// Only run Phoenix tuner server on the Rio, disable it here for the Jetson
+			ctre::phoenix::unmanaged::Unmanaged::SetPhoenixDiagnosticsStartTime(-1);
+		}
 	}
 	ROS_INFO_STREAM("Phoenix Version String : " << ctre::phoenix::unmanaged::Unmanaged::GetPhoenixVersion());
 	Devices::setHALRobot(run_hal_robot_);
@@ -213,7 +221,9 @@ bool FRCRobotInterface<SIM>::init(ros::NodeHandle& root_nh, ros::NodeHandle &/*r
 	{
 		auto i = d->registerInterface();
 		if (i)
+		{
 			registerInterfaceManager(i);
+		}
 	}
 
 	// Orchestra needs a set of previously created TalonFXs to use as instruments

--- a/zebROS_ws/src/ros_control_boilerplate/src/frc_robot_interface.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frc_robot_interface.cpp
@@ -155,6 +155,7 @@ bool FRCRobotInterface<SIM>::init(ros::NodeHandle& root_nh, ros::NodeHandle &/*r
 	}
 	ROS_INFO_STREAM("Phoenix Version String : " << ctre::phoenix::unmanaged::Unmanaged::GetPhoenixVersion());
 	Devices::setHALRobot(run_hal_robot_);
+	Devices::setRobotHW(this);
 
 	// Create all the devices specified in the yaml joint list, one type at a time
 	// Those that need different code for sim vs real hardware are templated using

--- a/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_sim_interface.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_sim_interface.cpp
@@ -60,7 +60,6 @@ bool FRCRobotSimInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot
 	FRCRobotInterface::readParams(root_nh, robot_hw_nh);
 	// Do base class init. This loads common interface info
 	// used by both the real and sim interfaces
-	ROS_WARN_STREAM(__PRETTY_FUNCTION__ << " line: " << __LINE__);
 
 	if (!FRCRobotInterface::init(root_nh, robot_hw_nh))
 	{
@@ -103,7 +102,6 @@ void FRCRobotSimInterface::read(const ros::Time &time, const ros::Duration &peri
 	{
 		d->simPostRead(time, period, *read_tracer_);
 	}
-
 }
 
 template <class T>

--- a/zebROS_ws/src/ros_control_boilerplate/src/sim_talonfxpro_device.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/sim_talonfxpro_device.cpp
@@ -167,7 +167,7 @@ void SimTalonFXProDevice::simRead(const ros::Time &/*time*/, const ros::Duration
         sim_state.SetRawRotorPosition(position);
         if (cancoder_id_)
         {
-            ROS_WARN_STREAM("cancoder id = " << *cancoder_id_ << " cancoder_value = " << cancoder_position.value());
+            // ROS_WARN_STREAM("cancoder id = " << *cancoder_id_ << " cancoder_value = " << cancoder_position.value());
             cancoder_->setRawPosition(cancoder_position.value());
         }
         sim_state.SetRotorVelocity(velocity);

--- a/zebROS_ws/src/ros_control_boilerplate/src/talonfxpro_devices.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/talonfxpro_devices.cpp
@@ -63,6 +63,14 @@ hardware_interface::InterfaceManager *TalonFXProDevices<SIM>::registerInterface(
     }
     interface_manager_.registerInterface(state_interface_.get());
     interface_manager_.registerInterface(command_interface_.get());
+    if constexpr (SIM)
+    {
+        for (const auto &d : devices_)
+        {
+            d->registerSimInterface(*state_interface_, *sim_fields_.sim_command_interface_);
+        }
+        interface_manager_.registerInterface(sim_fields_.sim_command_interface_.get());
+    }
     return &interface_manager_;
 }
 

--- a/zebROS_ws/src/ros_control_boilerplate/src/talonfxpro_devices.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/talonfxpro_devices.cpp
@@ -5,6 +5,7 @@
 #include "ros_control_boilerplate/sim_talonfxpro_device.h"
 #include "ros_control_boilerplate/read_config_utils.h"
 #include "ctre_interfaces/talonfxpro_command_interface.h"
+#include "ctre_interfaces/cancoder_sim_command_interface.h"
 
 template <bool SIM>
 TalonFXProDevices<SIM>::TalonFXProDevices(ros::NodeHandle &root_nh) 
@@ -107,7 +108,7 @@ void TalonFXProDevices<SIM>::simPreRead(const ros::Time& time, const ros::Durati
         tracer.start_unique("talonfxpro sim");
         for (const auto &d : devices_)
         {
-            d->simRead(time, period);
+            d->simRead(time, period, getRobotHW()->get<hardware_interface::cancoder::CANCoderSimCommandInterface>());
         }
     }
 }

--- a/zebROS_ws/src/ros_control_boilerplate/src/talonfxpro_hw_devices.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/talonfxpro_hw_devices.cpp
@@ -1,5 +1,4 @@
 #include <hardware_interface/robot_hw.h> // for hardware_interface::InterfaceManager
 #include "../src/talonfxpro_devices.cpp"
-#include "../src/talonfxpro_device.cpp"
 
 template class TalonFXProDevices<false>;

--- a/zebROS_ws/src/ros_control_boilerplate/src/talonfxpro_sim_devices.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/talonfxpro_sim_devices.cpp
@@ -1,6 +1,4 @@
 #include <hardware_interface/robot_hw.h> // for hardware_interface::InterfaceManager
-#include "ros_control_boilerplate/talonfxpro_devices.h"
 #include "../src/talonfxpro_devices.cpp"
-#include "../src/talonfxpro_device.cpp"
 
 template class TalonFXProDevices<true>;


### PR DESCRIPTION
Expose RobotHW pointer to Devices as a static member. Allow derived classes to access it, getting interfaces and handles as if each devices class was a controller.
Add a cancoder sim command interface allowing sets of various sim fields.
Get cancoder sim command interface inside talon simRead() and use it to query cancoder config and write sim values

Need to hook up sim cancoder device update() function which actually writes the queued commands to the CTRE cancoder sim